### PR TITLE
Update repo name from pds-website to rms-website in deploy scripts

### DIFF
--- a/deploy/deploy_website_to_production.sh
+++ b/deploy/deploy_website_to_production.sh
@@ -10,7 +10,7 @@ if [ x$confirm != "xY" ] && [ x$confirm != "x" ] && [ x$confirm != "xy" ]
 then
   exit 0
 fi
-cd ~/pds-website/website
+cd ~/rms-website/website
 echo "--- START DIFFS ---"
 diff -rq _site ${MASTER_DIR} | grep -v "Only in ${MASTER_DIR}" | grep -v "Common subdirectories"
 echo "--- END DIFFS ---"

--- a/deploy/deploy_website_to_staging.sh
+++ b/deploy/deploy_website_to_staging.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/bash
 source config_data
 branch=${1:-main}
-echo "### Deploying pds-website repo, branch ${branch}, to staging server"
-cd ~/pds-website
+echo "### Deploying rms-website repo, branch ${branch}, to staging server"
+cd ~/rms-website
 git checkout $branch
 if [ $? -ne 0 ]; then exit -1; fi
 git pull


### PR DESCRIPTION
We recently updated the repo name from pds-website to rms-website.  This change must be reflected in the deploy scripts, which aren't working properly otherwise.