### PR TITLE
Add baseurl and other minor changes

### DIFF
--- a/website/_config.yml
+++ b/website/_config.yml
@@ -3,7 +3,6 @@ title: Ring-Moon Systems Node
 email: pds-admin@seti.org
 description: > # this means to ignore newlines until "baseurl:"
     The Ring-Moon Systems Node of NASA's Planetary Data System is devoted to archiving, cataloging, and distributing scientific data sets relevant to planetary rings and moons, and the ways they interact.
-baseurl: "" # the subpath of your site, e.g. /blog/
 # url: "http://yourdomain.com" # the base hostname & protocol for your site
 # twitter_username: jekyllrb
 # github_username:  jekyll

--- a/website/_includes/breadcrumbs.html
+++ b/website/_includes/breadcrumbs.html
@@ -2,7 +2,7 @@
 {% assign crumbs = page.url | remove:'/index.html' | split: '/' %}
 <a href="{{ site.baseurl }}/">Home</a>
 {% if page.breadcrumb %}
-    / <a href="/{{ site.baseurl}}{{ page.breadcrumb }}">{{ page.breadcrumb | replace: "_", " " | capitalize }}</a> / {{ page.title }}
+    / <a href="/{{ site.baseurl }}{{ page.breadcrumb }}">{{ page.breadcrumb | replace: "_", " " | capitalize }}</a> / {{ page.title }}
 {% else %}
     {% for crumb in crumbs offset: 1 %}
         {% if forloop.last %}

--- a/website/_includes/breadcrumbs.html
+++ b/website/_includes/breadcrumbs.html
@@ -1,14 +1,14 @@
 <div id="breadcrumbs">
 {% assign crumbs = page.url | remove:'/index.html' | split: '/' %}
-<a href="/">Home</a>
+<a href="{{ site.baseurl }}/">Home</a>
 {% if page.breadcrumb %}
-    / <a href="/{{ page.breadcrumb }}">{{ page.breadcrumb | replace: "_", " " | capitalize }}</a> / {{ page.title }}
+    / <a href="/{{ site.baseurl}}{{ page.breadcrumb }}">{{ page.breadcrumb | replace: "_", " " | capitalize }}</a> / {{ page.title }}
 {% else %}
     {% for crumb in crumbs offset: 1 %}
         {% if forloop.last %}
             / {{ page.title }}
         {% else %}
-            / <a href="{% assign crumb_limit = forloop.index | plus: 1 %}{% for crumb in crumbs limit: crumb_limit %}{{ crumb | append: '/' | replace:'without-plugin/','without-plugins/' }}{% endfor %}">{{ crumb | replace:'-',' ' | crumb | replace:'_',' ' | remove:'.html' | capitalize }}</a>
+            / <a href="{{ site.baseurl }}{% assign crumb_limit = forloop.index | plus: 1 %}{% for crumb in crumbs limit: crumb_limit %}{{ crumb | append: '/' | replace:'without-plugin/','without-plugins/' }}{% endfor %}">{{ crumb | replace:'-',' ' | crumb | replace:'_',' ' | remove:'.html' | capitalize }}</a>
         {% endif %}
     {% endfor %}
 {% endif %}

--- a/website/_includes/homepage_inner.html
+++ b/website/_includes/homepage_inner.html
@@ -1,11 +1,9 @@
 <div class = "row">
     <div class = "col-md-12">
-
-             <p class = "mission_statement">
-                The Ring-Moon Systems Node of NASA's <a href="https://pds.nasa.gov/" target="_blank">Planetary Data System (PDS)</a>
-                is devoted to archiving, cataloging, and distributing scientific data sets relevant to planetary systems,
-                including planets, rings, and moons and the ways they interact.
-             </p>
-
+        <p class = "mission_statement">
+        The Ring-Moon Systems Node of NASA's <a href="https://pds.nasa.gov/" target="_blank">Planetary Data System (PDS)</a>
+        is devoted to archiving, cataloging, and distributing scientific data sets relevant to planetary systems,
+        including planets, rings, and moons and the ways they interact.
+        </p>
     </div>
 </div>

--- a/website/_includes/nav.html
+++ b/website/_includes/nav.html
@@ -20,7 +20,7 @@
               class = "active"
             {% endif %}
             >
-            <a href = "{{ item.href }}"
+            <a href = "{{ site.baseurl }}{{ item.href }}"
             {% if item.open contains 'new_tab' %}target="_blank"{% endif %}
             >{{ item.title }}</a>
 

--- a/website/_includes/tabs.html
+++ b/website/_includes/tabs.html
@@ -16,11 +16,11 @@
 
 		<ol class="breadcrumb">
 
-			<li><a href="/{{ tab.parent_tabs_yaml }}">{{ tab.parent_label }}</a></li>
+			<li><a href="/{{ tab.parent_tabs_yaml | relative_url}}">{{ tab.parent_label }}</a></li>
 
 			{% for p_tab in parent_tabs %}
 				{% if p_tab.title == tab.parent_tab %}
-					<li><a href="{{ p_tab.href }}">{{ tab.parent_tab }}</a></li>
+					<li><a href="{{ p_tab.href | relative_url }}">{{ tab.parent_tab }}</a></li>
 					{% continue %}
 				{% endif %}
 			{% endfor %}
@@ -31,7 +31,7 @@
                 {% assign label = page.title %}
             {% endif %}
             {% if page.breadcrumb %}
-                <li class = "active"><a href="{{ page.breadcrumb }}">{{ label }}</a></li>
+                <li class = "active"><a href="{{ page.breadcrumb | relative_url }}">{{ label }}</a></li>
             {% else %}
 			    <li class = "active">{{ label }}</li>
             {% endif %}
@@ -46,15 +46,14 @@
 	{% for tab in all_tabs %}
 
 		{% if tab.title %}
-		  <li class="tab-pill 
+		  <li class="tab-pill
 		  		{% if active_tab.title == tab.title %}
 		  			active
 		  		{% endif %}
 
-		  	" >	<a href="{{ tab.href }}">{{ tab.title }}</a>
+		  	" >	<a href="{{ tab.href | relative_url }}">{{ tab.title }}</a>
 		  </li>
 		{% endif %}
 	{% endfor %}
 
 </ul>
-

--- a/website/_layouts/base.html
+++ b/website/_layouts/base.html
@@ -20,7 +20,7 @@
 			{% endif %}
 
 			<div class = "col-md-12 col-sm-12">
-           
+
               {% assign page_url_path_split = page.url | split: "/" %}
               {% assign page_class = page_url_path_split[1] %}
 
@@ -78,6 +78,6 @@
 
   <!-- notifications modal -->
   <script src="{{ "/assets/js/notify.js" | prepend: site.baseurl }}" type="text/javascript"></script>
-  
+
   </body>
 </html>

--- a/website/astrometry/index.html
+++ b/website/astrometry/index.html
@@ -11,11 +11,11 @@ will be updated as new volumes are released. Satellites are identified by
 their NAIF IDs. A table of NAIF IDs  for the inner Saturnian satellites is
 provided at the bottom of the page.
 
-  * Clicking on the VOLUME_ID will allow you to browse the volume. 
+  * Clicking on the VOLUME_ID will allow you to browse the volume.
 
-  * To download an entire volume, right click on that volume's "Bundled" link in the second column. 
+  * To download an entire volume, right click on that volume's "Bundled" link in the second column.
 
-The bundled volumes are provided in [tar.gz](/help/targz.html) format.
+The bundled volumes are provided in [tar.gz]({{ site.baseurl }}/help/targz.html) format.
 
 ## Saturn Satellite Astrometry
 
@@ -32,4 +32,4 @@ The bundled volumes are provided in [tar.gz](/help/targz.html) format.
 {% assign table_name = "NAIF IDs for the inner Saturn Satellites" %}
 {% assign table_desc = "A listing of NAIF IDs for the inner Saturn Satellites" %}
 {% assign table_data = site.data.tables['astrometry_naif_ids'] %}
-{% include data_table.html %}  
+{% include data_table.html %}

--- a/website/cassini/cirs/access_orig.html
+++ b/website/cassini/cirs/access_orig.html
@@ -8,7 +8,7 @@ tabs: cassini_cirs
 
   * Use **[OPUS]({{ site.opus_url }}){:target="_blank"}**, our versatile search engine to find and retrieve specific Cassini CIRS data products using a wide range of criteria. However, OPUS currently only supports CIRS data submitted prior to July 2011.
 
-    * Search results include data files, tables of associated metadata, and footprint diagrams for each observation. User selected data files can be bundled as [tar.gz](/help/targz.html) files for easy downloading.
+    * Search results include data files, tables of associated metadata, and footprint diagrams for each observation. User selected data files can be bundled as [tar.gz]({{ site.baseurl }}/help/targz.html) files for easy downloading.
 
     * **Note: The results returned by OPUS are the reformatted versions of CIRS.** However, users can use the returned tables of metadata to identify the corresponding original format data.
 
@@ -22,7 +22,7 @@ tabs: cassini_cirs
 
     * To download an entire volume, right click on that volume's "Bundled" link in the second column.
 
-The bundled volumes are provided in [tar.gz](/help/targz.html) format.
+The bundled volumes are provided in [tar.gz]({{ site.baseurl }}/help/targz.html) format.
 
 Be aware that even with a 4:1 compression ratio, the bundled versions can be
 on the order of 4GB and may take a few hours to download. Users are encouraged
@@ -34,7 +34,7 @@ to download during the late night/early morning hours California time.
 
   * The dates at the beginning of each section in the table below correspond to **the scheduled delivery to PDS.**
 
-  * To determine which volumes meet the publicly available criteria for a specific ROSES Announcement please see the appropriate DAP page under our [Proposal Support](/roses) pages.
+  * To determine which volumes meet the publicly available criteria for a specific ROSES Announcement please see the appropriate DAP page under our [Proposal Support]({{ site.baseurl }}/roses) pages.
 
 
 {% assign table_name = "Cassini CIRS Original Releases" %}

--- a/website/cassini/cirs/access_reform.html
+++ b/website/cassini/cirs/access_reform.html
@@ -7,7 +7,7 @@ tabs: cassini_cirs
 
   * Use **[OPUS]({{ site.opus_url }}){:target="_blank"}**, our versatile search engine to find and retrieve specific Cassini CIRS data products using a wide range of criteria. However, OPUS currently only supports CIRS data submitted prior to July 2011.
 
-      * Search results include data files, tables of associated meta data, and footprint diagrams for each observation. User selected data files can be bundled as [tar.gz](/help/targz.html) files for easy downloading.
+      * Search results include data files, tables of associated meta data, and footprint diagrams for each observation. User selected data files can be bundled as [tar.gz]({{ site.baseurl }}/help/targz.html) files for easy downloading.
 
     * The table below contains links to all of the available data volumes from the Saturn encounter re-formatted into fixed length data files. For information on the re-formatted data, see [About Re-formatted Data.](reform_about.html)
 
@@ -15,7 +15,7 @@ tabs: cassini_cirs
 
       * **Download** an entire volume, by right clicking on that volume's "Bundled" link in the second column.
 
-The bundled volumes are provided in [tar.gz](/help/targz.html) format.
+The bundled volumes are provided in [tar.gz]({{ site.baseurl }}/help/targz.html) format.
 
 Be aware that even with a 4:1 compression ratio, the Bundled versions can be
 on the order of 4GB and may take a few hours to download. Users are encouraged
@@ -29,7 +29,7 @@ The footprint diagrams contain a wealth of information. The key for these diagra
 
   * The dates at the beginning of each section in the table below correspond to **the scheduled delivery to PDS.**
 
-  * To determine which volumes meet the publicly available criteria for a specific ROSES Announcement please see the appropriate DAP page under our [Proposal Support](/roses) pages.
+  * To determine which volumes meet the publicly available criteria for a specific ROSES Announcement please see the appropriate DAP page under our [Proposal Support]({{ site.baseurl }}/roses) pages.
 
   * **All reformtted volumes are based on version 2 of the original format data.**
 

--- a/website/cassini/cirs/index.html
+++ b/website/cassini/cirs/index.html
@@ -20,7 +20,7 @@ formats.
 
 **Cassini CIRS Data User Guide**.
 
-  * The **[CIRS User Guide](/holdings/documents/COCIRS_0xxx/CIRS-Users-Guide.pdf){:target="_blank"}** is available from the PDS Ring-Moon Systems Node holdings. 
+  * The **[CIRS User Guide](/holdings/documents/COCIRS_0xxx/CIRS-Users-Guide.pdf){:target="_blank"}** is available from the PDS Ring-Moon Systems Node holdings.
 
 ##  The CIRS Tabs
 

--- a/website/cassini/cirs/orig_doc.html
+++ b/website/cassini/cirs/orig_doc.html
@@ -9,14 +9,14 @@ title: "CIRS Documentation"
   * [Finding Data](orig_finding.html)
   * [Documentation](orig_doc.html)
 
-  
+
 ## 1.Documentation
 
 Please read the documentation carefully. The CIRS team has made a remarkable
 effort to provide useful information, including providing calibrated spectra
 for all of their data.
 
-** Users are strongly encouraged to review a CIRS <a href="orig_AAREADME.TXT" target="_blank">AAREADME.TXT</a> file.** This file appears in the root directory of every volume and provides a good overview of the data set. 
+** Users are strongly encouraged to review a CIRS <a href="orig_AAREADME.TXT" target="_blank">AAREADME.TXT</a> file.** This file appears in the root directory of every volume and provides a good overview of the data set.
 
 A number of additional documents are included in the
 [DOCUMENT](/link/volumes/COCIRS_0xxx/COCIRS_0403/DOCUMENT/) subdirectory on each volume. Those
@@ -27,8 +27,8 @@ In particular, further details of the CIRS archive volumes can be found in the
 "Software Interface Specification" (SIS) Documents, found in the DOCUMENTS
 directory on each volume.
 
-  * The Data Product and Label SIS is available as <a href="DATASIS.PDF" target="_blank">DOCUMENT/DATASIS.PDF</a> and <a href="DATASIS.txt" target="_blank">DOCUMENT/DATASIS.TEX</a>. 
-  * The Volume Organization SIS is available as <a href="VOLSIS.PDF" target="_blank">DOCUMENT/VOLSIS.PDF</a> and <a href="VOLSIS.txt" target="_blank">DOCUMENT/VOLSIS.TEX</a>. 
+  * The Data Product and Label SIS is available as <a href="DATASIS.PDF" target="_blank">DOCUMENT/DATASIS.PDF</a> and <a href="DATASIS.txt" target="_blank">DOCUMENT/DATASIS.TEX</a>.
+  * The Volume Organization SIS is available as <a href="VOLSIS.PDF" target="_blank">DOCUMENT/VOLSIS.PDF</a> and <a href="VOLSIS.txt" target="_blank">DOCUMENT/VOLSIS.TEX</a>.
 
 The [CATALOG](/link/volumes/COCIRS_0xxx/COCIRS_0403/CATALOG/) subdirectory on each volume
 contains a wealth of information about the CIRS instrument, team and data set.
@@ -52,4 +52,3 @@ Additional descriptions of the instrument can be found at the <a href="https://s
   * Access [ the original format data](access_orig.html)
 
   * Return to [About CIRS Data](about.html)
-

--- a/website/cassini/cirs/orig_finding.html
+++ b/website/cassini/cirs/orig_finding.html
@@ -16,7 +16,7 @@ title: "Finding the CIRS Data You Want"
 
   * **Use our search engine, [OPUS]({{ site.opus_url }}){:target="_blank"} to search for specific Cassini CIRS data products using a wide range of criteria.**
 
-    * Search results include data files, tables of associated metadata, and footprint diagrams for each observation. User selected data files can be bundled as [tar.gz](/help/targz.html) files for easy downloading.
+    * Search results include data files, tables of associated metadata, and footprint diagrams for each observation. User selected data files can be bundled as [tar.gz]({{ site.baseurl }}/help/targz.html) files for easy downloading.
 
   * The [Access Original Format Data](access_orig.html) tab, provides a link to each volume and gives the time interval covered by the volume.
 

--- a/website/cassini/cirs/reform_finding.html
+++ b/website/cassini/cirs/reform_finding.html
@@ -16,7 +16,7 @@ title: "Finding the CIRS Data You Want"
 
   * **Use our search engine, [OPUS]({{ site.opus_url }}){:target="_blank"} to search for specific Cassini CIRS data products using a wide range of criteria.**
 
-    * Search results include data files, tables of associated metadata, and footprint diagrams for each observation. User selected data files can be bundled as [tar.gz](/help/targz.html) files for easy downloading.
+    * Search results include data files, tables of associated metadata, and footprint diagrams for each observation. User selected data files can be bundled as [tar.gz]({{ site.baseurl }}/help/targz.html) files for easy downloading.
 
   * The [Access Re-formatted Data](access_reform.html) tab, provides a link to each volume and gives the time interval covered by the volume.
 

--- a/website/cassini/enhanced.html
+++ b/website/cassini/enhanced.html
@@ -37,22 +37,22 @@ established as an overall clearing house for Cassini support.
 <p></p>
   * **Calibrated ISS images**
 
-    * Links to calibrated Jupiter encounter images by volume are available from the table on the **[Accessing ISS Cruise Data](/cassini/iss/access_cruise.html)** page.
-    * Links to calibrated Saturn encounter images by volume are available from the table on the **[Accessing ISS Data](/cassini/iss/access.html)** page.
+    * Links to calibrated Jupiter encounter images by volume are available from the table on the **[Accessing ISS Cruise Data]({{ site.baseurl }}/cassini/iss/access_cruise.html)** page.
+    * Links to calibrated Saturn encounter images by volume are available from the table on the **[Accessing ISS Data]({{ site.baseurl }}/cassini/iss/access.html)** page.
     * The images are also available for browsing in the **[calibrated directory](/link/calibrated)**,
-    * and as **[tar.gz](/help/targz.html)** files for downloading by volume in the **[calibrated archives directory](/link/archives-calibrated)**.
+    * and as **[tar.gz]({{ site.baseurl }}/help/targz.html)** files for downloading by volume in the **[calibrated archives directory](/link/archives-calibrated)**.
 <p></p>
   * **Cassini Occultaton Data Sets**
 
-    * UVIS stellar occultation profiles of Saturn's rings, available from our **[UVIS information pages](/cassini/uvis/index.html)**.
-    * VIMS stellar occultation profiles of Saturn's rings, available from our **[VIMS information pages](/cassini/vims/index.html)**.
-    * RSS radio occultation profiles of Saturn's rings, available from our **[RSS information pages](/cassini/rss/index.html)**.
+    * UVIS stellar occultation profiles of Saturn's rings, available from our **[UVIS information pages]({{ site.baseurl }}/cassini/uvis/index.html)**.
+    * VIMS stellar occultation profiles of Saturn's rings, available from our **[VIMS information pages]({{ site.baseurl }}/cassini/vims/index.html)**.
+    * RSS radio occultation profiles of Saturn's rings, available from our **[RSS information pages]({{ site.baseurl }}/cassini/rss/index.html)**.
 <p></p>
   * **New or updated data user's guides**
 
     * **[CIRS User Guide]({{ site.holdings_url }}documents/COCIRS_0xxx/CIRS-Users-Guide.pdf){:target="_blank"}** - Version 11.7, November 2014.
     * **[ISS Data User's Guide]({{ site.holdings_url }}documents/COISS_0xxx/ISS-Users-Guide.pdf){:target="_blank"}** - Revised in September 2018.
-    * **[RSS Data User Guide](/cassini/rss/Cassini Radio Science Users Guide - 30 Sep 2018.pdf){:target="_blank"}** - Version 1.1, September 2018.
+    * **[RSS Data User Guide]({{ site.baseurl }}/cassini/rss/Cassini Radio Science Users Guide - 30 Sep 2018.pdf){:target="_blank"}** - Version 1.1, September 2018.
     * **[UVIS User's Guide]({{ site.holdings_url }}documents/COUVIS_8xxx/UVIS-Users-Guide.pdf){:target="_blank"}** - Revised in July 2018.
 <p></p>
   * **Downloadable tables of enhanced geometric metadata**

--- a/website/cassini/index.html
+++ b/website/cassini/index.html
@@ -91,7 +91,7 @@ planet and satellite searches as well as enhanced ring geometry.
     * Supports all scientific disciplines, **including atmospheres and geoscience**, in addition to ring science.
 
     * Search results include data files, tables of associated metadata, and browse products.
-      Selected data files can be bundled as [tar.gz](/help/targz.html) files for easy downloading.
+      Selected data files can be bundled as [tar.gz]({{ site.baseurl }}/help/targz.html) files for easy downloading.
 
   * Use **[Viewmaster](/viewmaster/volumes/)**
 to explore the PDS3 delivery volumes directly. Products are generally in chronological order.

--- a/website/cassini/iss/access.html
+++ b/website/cassini/iss/access.html
@@ -13,7 +13,7 @@ our versatile search engine to find and retrieve specific Cassini ISS data produ
 
     * **Calibrated versions of each Cassini ISS image can be downloaded from OPUS search results.**
 
-    * Search results also include raw images, tables of associated metadata, and thumbnail images for each observation. User selected data files can be bundled as [tar.gz](/help/targz.html) files for easy downloading.
+    * Search results also include raw images, tables of associated metadata, and thumbnail images for each observation. User selected data files can be bundled as [tar.gz]({{ site.baseurl }}/help/targz.html) files for easy downloading.
 
   * **[Viewmaster]({{ site.viewmaster_url }}){:target="_blank"}** is our new (2018) tool for browsing our on-line data volumes. This link takes you directly to the volumes directory. COISS_0xxx contains calibration files and software. COISS_1xxx contains the Jupiter encounter observations. COISS_2xxx contains the Saturn encounter observations. COISS_3xxx contains Cassini Cartographic Maps.
 
@@ -33,7 +33,7 @@ our versatile search engine to find and retrieve specific Cassini ISS data produ
 
     * To download an entire volume, right click on that volume's "Bundled" link in the second column.
 
-The bundled volumes are provided in [tar.gz](/help/targz.html) format.
+The bundled volumes are provided in [tar.gz]({{ site.baseurl }}/help/targz.html) format.
 
   * Browse images for each volume can be viewed by following the "Browse Images" link for that volume.
 
@@ -43,7 +43,7 @@ The bundled volumes are provided in [tar.gz](/help/targz.html) format.
 
   * The dates at the beginning of each section in the table below correspond to **the scheduled delivery to PDS.**
 
-  * To determine which volumes meet the publicly available criteria for a specific ROSES Announcement please see the appropriate DAP page under our [Proposal Support](/roses) pages.
+  * To determine which volumes meet the publicly available criteria for a specific ROSES Announcement please see the appropriate DAP page under our [Proposal Support]({{ site.baseurl }}/roses) pages.
 
   * The content of the /document/report/ subdirectory on each data volume provides summaries of the data quality and image anomalies present on that volume.
 

--- a/website/cassini/iss/access_cruise.html
+++ b/website/cassini/iss/access_cruise.html
@@ -4,7 +4,7 @@ layout_style: default
 title: "ISS Cruise and Jupiter Data"
 ---
 
-  
+
 ## Cruise and Jupiter Data
 
 * **For links to the complete calibration data set, see [ISS Calibration](calibration.html). **
@@ -14,13 +14,13 @@ title: "ISS Cruise and Jupiter Data"
 ### The table below contains links to all of the available data volumes up to
 Saturn approach.
 
-  * Clicking on the VOLUME_ID will allow you to browse the volume. 
+  * Clicking on the VOLUME_ID will allow you to browse the volume.
 
-  * To download an entire volume, right click on that volume's "Bundled" link in the second column. 
+  * To download an entire volume, right click on that volume's "Bundled" link in the second column.
 
-The bundled volumes are provided in [tar.gz](/help/targz.html) format.
+The bundled volumes are provided in [tar.gz]({{ site.baseurl }}/help/targz.html) format.
 
-  * Browse images for each volume can be viewed by following the "Browse Images" link for that volume. 
+  * Browse images for each volume can be viewed by following the "Browse Images" link for that volume.
 
 ### Available Volumes
 
@@ -30,7 +30,6 @@ The bundled volumes are provided in [tar.gz](/help/targz.html) format.
 {% include data_table.html %}
 
 
-Note that the [DOCUMENT/REPORT]({{ site.viewmaster_url }}volumes/COISS_2xxx/COISS_2001/DOCUMENT/REPORT/){:target="_blank"} 
+Note that the [DOCUMENT/REPORT]({{ site.viewmaster_url }}volumes/COISS_2xxx/COISS_2001/DOCUMENT/REPORT/){:target="_blank"}
 subdirectory of each data volume summarizes the data quality and image
 anomalies present on that volume.
-

--- a/website/cassini/iss/calibration.html
+++ b/website/cassini/iss/calibration.html
@@ -15,7 +15,7 @@ tabs: cassini_iss
 Calibration software, the most recent version of CISSCAL is available on the
 [COISS_0011]({{ site.viewmaster_url }}volumes/COISS_0xxx/COISS_0011){:target="_blank"} volume. The entire volume can be
 downloaded by right clicking [here]({{ site.holdings_url }}archives-volumes/COISS_0xxx/COISS_0011.tar.gz)
-([tar.gz](/help/targz.html) format).
+([tar.gz]({{ site.baseurl }}/help/targz.html) format).
 
 For discussions of available ISS calibration and image analysis software, see
 [ISS Software](software.html).
@@ -61,7 +61,7 @@ camera and test.
 
   * To download an entire volume, right click on that volume's "Bundle" link in the second row of each section.
 
-The bundled volumes are provided in [tar.gz](/help/targz.html) format.
+The bundled volumes are provided in [tar.gz]({{ site.baseurl }}/help/targz.html) format.
 
 
 {% assign table_name = "Cassini ISS Calibration Test Data - Narrow Angle Camera" %}

--- a/website/cassini/iss/cartographic.html
+++ b/website/cassini/iss/cartographic.html
@@ -6,23 +6,23 @@ title: "ISS Cartographic Data"
 
 ## Cartographic Data
 
-  * Cartographic data for selected satellites of Saturn are being prepared by the [PDS Imaging Node](//pds-imaging.jpl.nasa.gov/){:target="_blank"}. 
+  * Cartographic data for selected satellites of Saturn are being prepared by the [PDS Imaging Node](//pds-imaging.jpl.nasa.gov/){:target="_blank"}.
 
-    * Clicking on the VOLUME_ID will allow you to browse the volume. 
+    * Clicking on the VOLUME_ID will allow you to browse the volume.
 
-    * To download an entire volume, right click on that volume's "Bundle" link. 
+    * To download an entire volume, right click on that volume's "Bundle" link.
 
-The bundled volumes are provided in [tar.gz](/help/targz.html) format.
-
- 
+The bundled volumes are provided in [tar.gz]({{ site.baseurl }}/help/targz.html) format.
 
 
-Target | Volume ID | Bundle | 
----|---|---  
-**Phoebe** | [COISS_3001]({{ site.viewmaster_url }}volumes/COISS_3xxx/COISS_3001){:target="_blank"} | [COISS_3001.tar.gz]({{ site.holdings_url }}archives-volumes/COISS_3xxx/COISS_3001.tar.gz)  
-**Enceladus** | [COISS_3002]({{ site.viewmaster_url }}volumes/COISS_3xxx/COISS_3002){:target="_blank"} | [COISS_3002.tar.gz]({{ site.holdings_url }}archives-volumes/COISS_3xxx/COISS_3002.tar.gz)  
-**Dione** | [COISS_3003]({{ site.viewmaster_url }}volumes/COISS_3xxx/COISS_3003){:target="_blank"} | [COISS_3003.tar.gz]({{ site.holdings_url }}archives-volumes/COISS_3xxx/COISS_3003.tar.gz)  
-**Tethys** | [COISS_3004]({{ site.viewmaster_url }}volumes/COISS_3xxx/COISS_3004){:target="_blank"} | [COISS_3004.tar.gz]({{ site.holdings_url }}archives-volumes/COISS_3xxx/COISS_3004.tar.gz)  
-**Iapetus** | [COISS_3005]({{ site.viewmaster_url }}volumes/COISS_3xxx/COISS_3005){:target="_blank"} | [COISS_3005.tar.gz]({{ site.holdings_url }}archives-volumes/COISS_3xxx/COISS_3005.tar.gz)  
-**Mimas** | [COISS_3006]({{ site.viewmaster_url }}volumes/COISS_3xxx/COISS_3006){:target="_blank"} | [COISS_3006.tar.gz]({{ site.holdings_url }}archives-volumes/COISS_3xxx/COISS_3006.tar.gz)  
-**Rhea** | [COISS_3007]({{ site.viewmaster_url }}volumes/COISS_3xxx/COISS_3007){:target="_blank"} | [COISS_3007.tar.gz]({{ site.holdings_url }}archives-volumes/COISS_3xxx/COISS_3007.tar.gz)  
+
+
+Target | Volume ID | Bundle |
+---|---|---
+**Phoebe** | [COISS_3001]({{ site.viewmaster_url }}volumes/COISS_3xxx/COISS_3001){:target="_blank"} | [COISS_3001.tar.gz]({{ site.holdings_url }}archives-volumes/COISS_3xxx/COISS_3001.tar.gz)
+**Enceladus** | [COISS_3002]({{ site.viewmaster_url }}volumes/COISS_3xxx/COISS_3002){:target="_blank"} | [COISS_3002.tar.gz]({{ site.holdings_url }}archives-volumes/COISS_3xxx/COISS_3002.tar.gz)
+**Dione** | [COISS_3003]({{ site.viewmaster_url }}volumes/COISS_3xxx/COISS_3003){:target="_blank"} | [COISS_3003.tar.gz]({{ site.holdings_url }}archives-volumes/COISS_3xxx/COISS_3003.tar.gz)
+**Tethys** | [COISS_3004]({{ site.viewmaster_url }}volumes/COISS_3xxx/COISS_3004){:target="_blank"} | [COISS_3004.tar.gz]({{ site.holdings_url }}archives-volumes/COISS_3xxx/COISS_3004.tar.gz)
+**Iapetus** | [COISS_3005]({{ site.viewmaster_url }}volumes/COISS_3xxx/COISS_3005){:target="_blank"} | [COISS_3005.tar.gz]({{ site.holdings_url }}archives-volumes/COISS_3xxx/COISS_3005.tar.gz)
+**Mimas** | [COISS_3006]({{ site.viewmaster_url }}volumes/COISS_3xxx/COISS_3006){:target="_blank"} | [COISS_3006.tar.gz]({{ site.holdings_url }}archives-volumes/COISS_3xxx/COISS_3006.tar.gz)
+**Rhea** | [COISS_3007]({{ site.viewmaster_url }}volumes/COISS_3xxx/COISS_3007){:target="_blank"} | [COISS_3007.tar.gz]({{ site.holdings_url }}archives-volumes/COISS_3xxx/COISS_3007.tar.gz)

--- a/website/cassini/iss/finding.html
+++ b/website/cassini/iss/finding.html
@@ -12,7 +12,7 @@ tabs: cassini_iss
 
     * Supports CIRS (limited), ISS, UVIS, and VIMS.
 
-    * Search results include data files, tables of associated metadata, and browse thumbnails for each image. User selected data files can be bundled as [tar.gz](/help/targz.html) files for easy downloading.
+    * Search results include data files, tables of associated metadata, and browse thumbnails for each image. User selected data files can be bundled as [tar.gz]({{ site.baseurl }}/help/targz.html) files for easy downloading.
 
     * See section 4 below for additional hints on using OPUS.
 
@@ -20,10 +20,10 @@ tabs: cassini_iss
     at the [PDS Imaging Node](//pds-imaging.jpl.nasa.gov/){:target="_blank"} has been significantly upgraded and supports a wide range of criteria for Cassini ISS and VIMS data searches.
 
   * The [Access ISS Data](access.html) tab, provides links for each data volume, including links to the volume, to
-    [tar.gz](/help/targz.html)
+    [tar.gz]({{ site.baseurl }}/help/targz.html)
     files of the volume, and links to directories containing "thumbnail" previews of the images on the volume.
 
-  * The [ISS Calibration](calibration.html) tab, provides links for each calibration volume, including links to the volume and to [tar.gz](/help/targz.html) files of the volume.
+  * The [ISS Calibration](calibration.html) tab, provides links for each calibration volume, including links to the volume and to [tar.gz]({{ site.baseurl }}/help/targz.html) files of the volume.
 
   * You can use the VOLUME_ID coupled with the index files provided on the ISS volumes to help you find specific data (see below).
 

--- a/website/cassini/iss/index.html
+++ b/website/cassini/iss/index.html
@@ -7,7 +7,7 @@ tabs: cassini_iss
 ![\[SATURN APPROACH IMAGE\]](PIA06077.jpg)
 
 
-## Cassini ISS 
+## Cassini ISS
 
 
 The Cassini Imaging Science Subsystem (ISS) consists of two cameras, narrow-
@@ -37,7 +37,7 @@ between blue and near-infrared wavelengths.
   * [ISS Distortion](owen_2003_iss_distortion_model-1.pdf){:target="_blank"}. Provides an alternate Distortion Model for Cassini ISS.
 
 
-For mission highlights and press release images, see our [Cassini Gallery](/galleries/cassini.html). You can also find more at JPL's [Cassini home
+For mission highlights and press release images, see our [Cassini Gallery]({{ site.baseurl }}/galleries/cassini.html). You can also find more at JPL's [Cassini home
 page](//saturn.jpl.nasa.gov/){:target="_blank"}.
 
 **If you are unfamiliar with scientific image formats, consider taking Emily Lakdawalla's free on-line course, [Basics of Digital Imaging](//courses.planetary.org/p/imageclass){:target="_blank"}.**

--- a/website/cassini/rss/index.html
+++ b/website/cassini/rss/index.html
@@ -9,33 +9,32 @@ tabs: cassini_rss
 
 ##  Update September 2018: Cassini RSS Data Users Guide
 
-  * An updated **[RSS Data Users Guide](/cassini/rss/Cassini Radio Science Users Guide - 30 Sep 2018.pdf){:target="_blank"}** (Version 1.1) is available.
+  * An updated **[RSS Data Users Guide]({{ site.baseurl }}/cassini/rss/Cassini Radio Science Users Guide - 30 Sep 2018.pdf){:target="_blank"}** (Version 1.1) is available.
 
 ##  Update January 2019: RSS Radio Occultation Profiles
 
-  * The PDS Rings node has posted version 2 of the dataset of Saturn ring radial profiles derived from RSS radio occultation data. 
+  * The PDS Rings node has posted version 2 of the dataset of Saturn ring radial profiles derived from RSS radio occultation data.
 
-  * You may browse the dataset [CORSS_8001]({{ site.viewmaster_url }}volumes/CORSS_8xxx){:target="_blank"}, or download the entire dataset 
-    [CORSS_8001 tar.gz]({{ site.holdings_url }}archives-volumes/CORSS_8xxx/CORSS_8001.tar.gz){:target="_blank"}. 
-    
-  * Version 2 includes reprocessed versions of the material contained in 
-    the earlier version, plus all subsequent RSS occultations 
-    obtained prior to the loss of the Cassini UltraStable 
+  * You may browse the dataset [CORSS_8001]({{ site.viewmaster_url }}volumes/CORSS_8xxx){:target="_blank"}, or download the entire dataset
+    [CORSS_8001 tar.gz]({{ site.holdings_url }}archives-volumes/CORSS_8xxx/CORSS_8001.tar.gz){:target="_blank"}.
+
+  * Version 2 includes reprocessed versions of the material contained in
+    the earlier version, plus all subsequent RSS occultations
+    obtained prior to the loss of the Cassini UltraStable
     Oscillator (USO) in late 2011.
-    
+
     In addition, this version includes 'DLP' files for each observation.
-    These contain higher resolution calibrated, but diffraction-limited, 
-    optical depth and phase shift profiles of Saturn's rings, that is, 
-    calibrated profiles before reconstruction to remove diffraction 
+    These contain higher resolution calibrated, but diffraction-limited,
+    optical depth and phase shift profiles of Saturn's rings, that is,
+    calibrated profiles before reconstruction to remove diffraction
     effects.
-    
-    While Version 1 contained only X band data files, version 2 contains 
+
+    While Version 1 contained only X band data files, version 2 contains
     K, S, and X band data.
-     
-    Details of the data processing involved in the production of this 
+
+    Details of the data processing involved in the production of this
     data set are provided in MAROUFETAL1986.
 
 
 NOTE: Raw RSS data may be obtained from the [PDS Atmospheres Node](//pds-
 atmospheres.nmsu.edu/){:target="_blank"}.
-

--- a/website/cassini/uvis/access.html
+++ b/website/cassini/uvis/access.html
@@ -50,7 +50,7 @@ You can **Search** for UVIS data using **[OPUS]({{ site.opus_url }}/instrument=C
 
     * Download an entire volume, by right clicking on that volume's "Bundled" link in the second table.
 
-The bundled volumes are provided in [tar.gz](/help/targz.html) format.
+The bundled volumes are provided in [tar.gz]({{ site.baseurl }}/help/targz.html) format.
 
     * Browse Images will take you to a directory containing sub-directories of preview images for each UVIS cube in the volume.
 
@@ -73,7 +73,7 @@ images is in [key for the UVIS previews]({{ site.holdings_url }}documents/COUVIS
 
   * The dates at the beginning of each section in the table below correspond to **the scheduled delivery date to PDS.**
 
-  * To determine which volumes meet the publicly available criteria for a specific ROSES Announcement please see the appropriate DAP page under our [Proposal Support](/roses) pages
+  * To determine which volumes meet the publicly available criteria for a specific ROSES Announcement please see the appropriate DAP page under our [Proposal Support]({{ site.baseurl }}/roses) pages
 
 
 {% assign table_name = "Cassini UVIS Releases" %}

--- a/website/cassini/uvis/finding.html
+++ b/website/cassini/uvis/finding.html
@@ -11,7 +11,7 @@ tabs: cassini_uvis
   * **Use [OPUS]({{ site.opus_url }}/instrument=Cassini+UVIS&mission=Cassini&widgets=mission,instrument,planet,target){:target="_blank"}
 to search for specific Cassini UVIS data products using a wide range of criteria including enhanced geometric metadata produced at the Rings node. The enhanced geometric metadata includes information appropriate to planet and satelllite searches as well as enhanced ring geometry.**
 
-    * Search results include data files, tables of associated metadata, and JPG previews for each observation. User selected data files can be bundled as [tar.gz](/help/targz.html) files for easy downloading.
+    * Search results include data files, tables of associated metadata, and JPG previews for each observation. User selected data files can be bundled as [tar.gz]({{ site.baseurl }}/help/targz.html) files for easy downloading.
 
   * The [Access UVIS Data](access.html) tab, associates volumes with data sets, and for each volume gives the time interval covered by the volume and provides a link to the volume.
 
@@ -65,7 +65,7 @@ a link to the volume.
 
 ###  4\. Volume INDEX Files
 
-All instruments provide some form of metadata index files in the folder called INDEX within each PDS3 volume. 
+All instruments provide some form of metadata index files in the folder called INDEX within each PDS3 volume.
 
-However, RMS Node using later available SPICE kernels, provides extensive metadata tables for this instrument. 
+However, RMS Node using later available SPICE kernels, provides extensive metadata tables for this instrument.
 They are available here: [metadata/COUVIS_0xxx]({{ site.viewmaster_url }}metadata/COUVIS_0xxx/COUVIS_0999){:target="_blank"}.

--- a/website/cassini/vims/access.html
+++ b/website/cassini/vims/access.html
@@ -40,7 +40,7 @@ of the available VIMS data volumes from cruise, Jupiter, and Saturn.
 
   * Download an entire volume, by right clicking on that volume's "Bundled" link in the second table.
 
-The bundled volumes are provided in [tar.gz](/help/targz.html) format.
+The bundled volumes are provided in [tar.gz]({{ site.baseurl }}/help/targz.html) format.
 
   * Browse Images will take you to a directory containing sub-directories of preview images for each VIMS cube in the volume.
 
@@ -51,7 +51,7 @@ images is in the [VIMS-Preview-Interpretation-Guide]({{ site.holdings_url }}docu
 
   * The dates at the beginning of each section in the table below correspond to **the scheduled delivery to PDS.**
 
-  * To determine which volumes meet the publicly available criteria for a specific ROSES Announcement please see the appropriate DAP page under our [Proposal Support](/roses) pages.
+  * To determine which volumes meet the publicly available criteria for a specific ROSES Announcement please see the appropriate DAP page under our [Proposal Support]({{ site.baseurl }}/roses) pages.
 
 {% assign table_name = "Cassini VIMS Releases" %}
 {% assign table_desc = "A listing of Cassini VIMS Releases" %}

--- a/website/galileo/vgr1_data.html
+++ b/website/galileo/vgr1_data.html
@@ -18,13 +18,13 @@ opus_share: /view=detail&detail=vg-iss-1-j-
 
 FDS |  Camera* |  Filter | Exposure | Elevation | Range     | Phase Angle | Content
 ---|---|---|---|---|---|---|---
-[16368.19]({{ site.opus_url }}{{ page.opus_share }}c1636819){:target="_blank"} | NA | Clear | 672 | 0.01 | 1215 | 0.55 | Main Ring terminus  
-  
-[*] NA = Narrow angle camera; WA = Wide angle camera. 
+[16368.19]({{ site.opus_url }}{{ page.opus_share }}c1636819){:target="_blank"} | NA | Clear | 672 | 0.01 | 1215 | 0.55 | Main Ring terminus
+
+[*] NA = Narrow angle camera; WA = Wide angle camera.
 
 * * *
 
 Related pages:
-* [Voyager Images](/voyager/iss/)
-* [Voyager Cameras](/voyager/iss/instrument.html)
-* [Voyager Mission](/voyager/index.html)
+* [Voyager Images]({{ site.baseurl }}/voyager/iss/)
+* [Voyager Cameras]({{ site.baseurl }}/voyager/iss/instrument.html)
+* [Voyager Mission]({{ site.baseurl }}/voyager/index.html)

--- a/website/galileo/vgr2_hiphase_data.html
+++ b/website/galileo/vgr2_hiphase_data.html
@@ -10,7 +10,7 @@ opus_share: /view=detail&detail=vg-iss-2-j-
 # Voyager 2 Outbound Jovian Ring Images
 {% assign image_table = site.data.tables['vrg2_hiphase_img'] %}
 {% include image-gallery.html %}
-  
+
 * * *
 
 ## Viewing Geometry Table
@@ -18,24 +18,24 @@ opus_share: /view=detail&detail=vg-iss-2-j-
 FDS |  Camera* |  Filter | Exposure | Elevation | Range     | Phase Angle | Content
     |          |         | (ms)     | (deg)     | (1000 km) | (deg)       |
 ---|---|---|---|---|---|---|---
-[20691.27]({{ site.opus_url }}{{ page.opus_share }}c2069127){:target="_blank"} | WA | Violet | 96 | -2.08 | 1500 | 175.4-176.2 | Main Ring, Halo, Shadow  
-[20691.31]({{ site.opus_url }}{{ page.opus_share }}c2069131){:target="_blank"} | WA | Orange | 96 | -2.07 | 1503 | 175.4-176.3 | Main Ring, Halo, Shadow  
-[20691.35]({{ site.opus_url }}{{ page.opus_share }}c2069135){:target="_blank"} | WA | Orange | 96 | -2.06 | 1505 | 176.2-176.9 | Main Ring, Halo, Shadow  
-[20691.39]({{ site.opus_url }}{{ page.opus_share }}c2069139){:target="_blank"} | WA | Violet | 96 | -2.05 | 1507 | 176.2-176.8 | Main Ring, Halo, Shadow  
-[20692.37]({{ site.opus_url }}{{ page.opus_share }}c2069237){:target="_blank"} | NA | Clear | 96 | -1.89 | 1539 | 175.7 | Main Ring, Halo  
-[20692.41]({{ site.opus_url }}{{ page.opus_share }}c2069241){:target="_blank"} | NA | Clear | 96 | -1.88 | 1541 | 175.5 | Main Ring, Halo  
-[20692.45]({{ site.opus_url }}{{ page.opus_share }}c2069245){:target="_blank"} | NA | Clear | 96 | -1.87 | 1544 | 175.1 | Main Ring, Halo  
-[20692.49]({{ site.opus_url }}{{ page.opus_share }}c2069249){:target="_blank"} | NA | Clear | 96 | -1.86 | 1546 | 174.7 | Main Ring, Halo  
-[20692.53]({{ site.opus_url }}{{ page.opus_share }}c2069253){:target="_blank"} | NA | Clear | 96 | -1.85 | 1548 | 174.4 | Main Ring, Halo  
-[20692.57]({{ site.opus_url }}{{ page.opus_share }}c2069257){:target="_blank"} | NA | Clear | 96 | -1.84 | 1550 | 174.1 | Main Ring, Halo  
-[20693.01]({{ site.opus_url }}{{ page.opus_share }}c2069301){:target="_blank"} | NA | Clear | 96 | -1.83 | 1552 | 173.8 | Gossamer Ring  
-[20693.02]({{ site.opus_url }}{{ page.opus_share }}c2069302){:target="_blank"} | WA | Clear | 15.36 | -1.82 | 1553 | 173.8-174.7 | Main Ring Ansa, Halo, Gossamer Ring  
-  
-[*] NA = Narrow angle camera; WA = Wide angle camera. 
+[20691.27]({{ site.opus_url }}{{ page.opus_share }}c2069127){:target="_blank"} | WA | Violet | 96 | -2.08 | 1500 | 175.4-176.2 | Main Ring, Halo, Shadow
+[20691.31]({{ site.opus_url }}{{ page.opus_share }}c2069131){:target="_blank"} | WA | Orange | 96 | -2.07 | 1503 | 175.4-176.3 | Main Ring, Halo, Shadow
+[20691.35]({{ site.opus_url }}{{ page.opus_share }}c2069135){:target="_blank"} | WA | Orange | 96 | -2.06 | 1505 | 176.2-176.9 | Main Ring, Halo, Shadow
+[20691.39]({{ site.opus_url }}{{ page.opus_share }}c2069139){:target="_blank"} | WA | Violet | 96 | -2.05 | 1507 | 176.2-176.8 | Main Ring, Halo, Shadow
+[20692.37]({{ site.opus_url }}{{ page.opus_share }}c2069237){:target="_blank"} | NA | Clear | 96 | -1.89 | 1539 | 175.7 | Main Ring, Halo
+[20692.41]({{ site.opus_url }}{{ page.opus_share }}c2069241){:target="_blank"} | NA | Clear | 96 | -1.88 | 1541 | 175.5 | Main Ring, Halo
+[20692.45]({{ site.opus_url }}{{ page.opus_share }}c2069245){:target="_blank"} | NA | Clear | 96 | -1.87 | 1544 | 175.1 | Main Ring, Halo
+[20692.49]({{ site.opus_url }}{{ page.opus_share }}c2069249){:target="_blank"} | NA | Clear | 96 | -1.86 | 1546 | 174.7 | Main Ring, Halo
+[20692.53]({{ site.opus_url }}{{ page.opus_share }}c2069253){:target="_blank"} | NA | Clear | 96 | -1.85 | 1548 | 174.4 | Main Ring, Halo
+[20692.57]({{ site.opus_url }}{{ page.opus_share }}c2069257){:target="_blank"} | NA | Clear | 96 | -1.84 | 1550 | 174.1 | Main Ring, Halo
+[20693.01]({{ site.opus_url }}{{ page.opus_share }}c2069301){:target="_blank"} | NA | Clear | 96 | -1.83 | 1552 | 173.8 | Gossamer Ring
+[20693.02]({{ site.opus_url }}{{ page.opus_share }}c2069302){:target="_blank"} | WA | Clear | 15.36 | -1.82 | 1553 | 173.8-174.7 | Main Ring Ansa, Halo, Gossamer Ring
+
+[*] NA = Narrow angle camera; WA = Wide angle camera.
 
 * * *
 
 Related pages:
-* [Voyager Images](/voyager/iss/)
-* [Voyager Cameras](/voyager/iss/instrument.html)
-* [Voyager Mission](/voyager/index.html)
+* [Voyager Images]({{ site.baseurl }}/voyager/iss/)
+* [Voyager Cameras]({{ site.baseurl }}/voyager/iss/instrument.html)
+* [Voyager Mission]({{ site.baseurl }}/voyager/index.html)

--- a/website/galileo/vgr2_lophase_data.html
+++ b/website/galileo/vgr2_lophase_data.html
@@ -19,24 +19,24 @@ opus_share: /view=detail&detail=vg-iss-2-j-
 FDS |  Camera* |  Filter | Exposure | Elevation | Range     | Phase Angle | Content
     |          |         | (ms)     | (deg)     | (1000 km) | (deg)       |
 ---|---|---|---|---|---|---|---
-[20612.27]({{ site.opus_url }}{{ page.opus_share }}c2061227){:target="_blank"}  | NA | Clear | 96 | 2.40 | 2003 | 2.6 | Main Ring  
-[20612.31]({{ site.opus_url }}{{ page.opus_share }}c2061231){:target="_blank"}  | NA | Clear | 96 | 2.39 | 2001 | 2.7 | Main Ring  
-[20630.20]({{ site.opus_url }}{{ page.opus_share }}c2063020){:target="_blank"}  | NA | Clear | 96 | -0.02 | 1407 | 16.6 | Main Ring  
-[20630.24]({{ site.opus_url }}{{ page.opus_share }}c2063024){:target="_blank"}  | NA | Clear | 96 | -0.04 | 1405 | 17.0 | Main Ring  
-[20630.28]({{ site.opus_url }}{{ page.opus_share }}c2063028){:target="_blank"}  | NA | Clear | 96 | -0.05 | 1403 | 17.4 | Main Ring  
-[20630.32]({{ site.opus_url }}{{ page.opus_share }}c2063032){:target="_blank"}  | NA | Clear | 96 | -0.06 | 1402 | 17.9 | Main Ring  
-[20630.36]({{ site.opus_url }}{{ page.opus_share }}c2063036){:target="_blank"}  | NA | Violet | 96 | -0.07 | 1400 | 18.1 | Main Ring  
-[20630.40]({{ site.opus_url }}{{ page.opus_share }}c2063040){:target="_blank"}  | NA | Orange | 96 | -0.08 | 1398 | 18.1 | Main Ring  
-[20630.44]({{ site.opus_url }}{{ page.opus_share }}c2063044){:target="_blank"}  | NA | Green | 96 | -0.09 | 1396 | 18.2 | Main Ring  
-[20630.48]({{ site.opus_url }}{{ page.opus_share }}c2063048){:target="_blank"}  | NA | Clear | 96 | -0.10 | 1394 | 18.6 | Main Ring, Adrastea  
-[20630.52]({{ site.opus_url }}{{ page.opus_share }}c2063052){:target="_blank"}  | NA | Clear | 96 | -0.12 | 1392 | 19.0 | Main Ring terminus  
-[20630.53]({{ site.opus_url }}{{ page.opus_share }}c2063053){:target="_blank"}  | WA | Clear | 15.36 | -0.12 | 1391 | 18.0-19.0 | Main Ring terminus, Halo?, Adrastea  
-  
-[*] NA = Narrow angle camera; WA = Wide angle camera. 
+[20612.27]({{ site.opus_url }}{{ page.opus_share }}c2061227){:target="_blank"}  | NA | Clear | 96 | 2.40 | 2003 | 2.6 | Main Ring
+[20612.31]({{ site.opus_url }}{{ page.opus_share }}c2061231){:target="_blank"}  | NA | Clear | 96 | 2.39 | 2001 | 2.7 | Main Ring
+[20630.20]({{ site.opus_url }}{{ page.opus_share }}c2063020){:target="_blank"}  | NA | Clear | 96 | -0.02 | 1407 | 16.6 | Main Ring
+[20630.24]({{ site.opus_url }}{{ page.opus_share }}c2063024){:target="_blank"}  | NA | Clear | 96 | -0.04 | 1405 | 17.0 | Main Ring
+[20630.28]({{ site.opus_url }}{{ page.opus_share }}c2063028){:target="_blank"}  | NA | Clear | 96 | -0.05 | 1403 | 17.4 | Main Ring
+[20630.32]({{ site.opus_url }}{{ page.opus_share }}c2063032){:target="_blank"}  | NA | Clear | 96 | -0.06 | 1402 | 17.9 | Main Ring
+[20630.36]({{ site.opus_url }}{{ page.opus_share }}c2063036){:target="_blank"}  | NA | Violet | 96 | -0.07 | 1400 | 18.1 | Main Ring
+[20630.40]({{ site.opus_url }}{{ page.opus_share }}c2063040){:target="_blank"}  | NA | Orange | 96 | -0.08 | 1398 | 18.1 | Main Ring
+[20630.44]({{ site.opus_url }}{{ page.opus_share }}c2063044){:target="_blank"}  | NA | Green | 96 | -0.09 | 1396 | 18.2 | Main Ring
+[20630.48]({{ site.opus_url }}{{ page.opus_share }}c2063048){:target="_blank"}  | NA | Clear | 96 | -0.10 | 1394 | 18.6 | Main Ring, Adrastea
+[20630.52]({{ site.opus_url }}{{ page.opus_share }}c2063052){:target="_blank"}  | NA | Clear | 96 | -0.12 | 1392 | 19.0 | Main Ring terminus
+[20630.53]({{ site.opus_url }}{{ page.opus_share }}c2063053){:target="_blank"}  | WA | Clear | 15.36 | -0.12 | 1391 | 18.0-19.0 | Main Ring terminus, Halo?, Adrastea
+
+[*] NA = Narrow angle camera; WA = Wide angle camera.
 
 * * *
 
 Related pages:
-* [Voyager Images](/voyager/iss/)
-* [Voyager Cameras](/voyager/iss/instrument.html)
-* [Voyager Mission](/voyager/index.html)
+* [Voyager Images]({{ site.baseurl }}/voyager/iss/)
+* [Voyager Cameras]({{ site.baseurl }}/voyager/iss/instrument.html)
+* [Voyager Mission]({{ site.baseurl }}/voyager/index.html)

--- a/website/galleries.html
+++ b/website/galleries.html
@@ -4,48 +4,48 @@ layout_style: default
 title: "Press Release Image Galleries"
 ---
 
-![Daphnis in the Keeler Gap](/news/cassini_daphnis_ianregan_crop.jpg)
+![Daphnis in the Keeler Gap]({{ site.baseurl }}/news/cassini_daphnis_ianregan_crop.jpg)
 
 # <strong>NASA Press Release Image Galleries</strong>
 
 ## By Planetary System
 
-  * [Mercury](/galleries/mercury.html)
-  * [Venus](/galleries/venus.html)
-  * Mars by [date](/galleries/mars.html) or [target](/galleries/target_mars.html)
-  * Jupiter by [date](/galleries/jupiter.html) or [target](/galleries/target_jupiter.html)
-  * Saturn by [date](/galleries/saturn.html) or [target](/galleries/target_saturn.html)
-  * Uranus by [date](/galleries/uranus.html) or [target](/galleries/target_uranus.html)
-  * Neptune by [date](/galleries/neptune.html) or [target](/galleries/target_neptune.html)
-  * Pluto by [date](/galleries/pluto.html) or [target](/galleries/target_pluto.html)
+  * [Mercury]({{ site.baseurl }}/galleries/mercury.html)
+  * [Venus]({{ site.baseurl }}/galleries/venus.html)
+  * Mars by [date]({{ site.baseurl }}/galleries/mars.html) or [target]({{ site.baseurl }}/galleries/target_mars.html)
+  * Jupiter by [date]({{ site.baseurl }}/galleries/jupiter.html) or [target]({{ site.baseurl }}/galleries/target_jupiter.html)
+  * Saturn by [date]({{ site.baseurl }}/galleries/saturn.html) or [target]({{ site.baseurl }}/galleries/target_saturn.html)
+  * Uranus by [date]({{ site.baseurl }}/galleries/uranus.html) or [target]({{ site.baseurl }}/galleries/target_uranus.html)
+  * Neptune by [date]({{ site.baseurl }}/galleries/neptune.html) or [target]({{ site.baseurl }}/galleries/target_neptune.html)
+  * Pluto by [date]({{ site.baseurl }}/galleries/pluto.html) or [target]({{ site.baseurl }}/galleries/target_pluto.html)
 
 ## By Target Type
 
-  * Asteroids by [date](/galleries/asteroids.html) or [target](/galleries/asteroid_1_ceres.html)
-  * Comets by [date](/galleries/comets.html) or [target](/galleries/comet_1p_halley.html)
-  * Kuiper Belt objects by [date](/galleries/kbos.html) or [target](/galleries/kbo_pluto.html)
-  * Exoplanetary systems by [date](/galleries/exoplanets.html) or [target](/galleries/exoplanet_55_cancri.html)
+  * Asteroids by [date]({{ site.baseurl }}/galleries/asteroids.html) or [target]({{ site.baseurl }}/galleries/asteroid_1_ceres.html)
+  * Comets by [date]({{ site.baseurl }}/galleries/comets.html) or [target]({{ site.baseurl }}/galleries/comet_1p_halley.html)
+  * Kuiper Belt objects by [date]({{ site.baseurl }}/galleries/kbos.html) or [target]({{ site.baseurl }}/galleries/kbo_pluto.html)
+  * Exoplanetary systems by [date]({{ site.baseurl }}/galleries/exoplanets.html) or [target]({{ site.baseurl }}/galleries/exoplanet_55_cancri.html)
 
 ## By Mission
 
-  * [Voyager](/galleries/voyager.html) to Jupiter, Saturn, Uranus, and Neptune
-  * [Galileo](/galleries/galileo.html) to Jupiter
-  * [Cassini](/galleries/cassini.html) to Jupiter and Saturn
-  * [New Horizons](/galleries/new_horizons.html) to Jupiter, Pluto, and 486958 Arrokoth
-  * [Juno](/galleries/juno.html) to Jupiter
-  * [Dawn](/galleries/dawn.html) to 4 Vesta and 1 Ceres
-  * [MESSENGER](/galleries/messenger.html) to Mercury
-  * [Rosetta](/galleries/rosetta.html) to 67P/Churyumov–Gerasimenko
+  * [Voyager]({{ site.baseurl }}/galleries/voyager.html) to Jupiter, Saturn, Uranus, and Neptune
+  * [Galileo]({{ site.baseurl }}/galleries/galileo.html) to Jupiter
+  * [Cassini]({{ site.baseurl }}/galleries/cassini.html) to Jupiter and Saturn
+  * [New Horizons]({{ site.baseurl }}/galleries/new_horizons.html) to Jupiter, Pluto, and 486958 Arrokoth
+  * [Juno]({{ site.baseurl }}/galleries/juno.html) to Jupiter
+  * [Dawn]({{ site.baseurl }}/galleries/dawn.html) to 4 Vesta and 1 Ceres
+  * [MESSENGER]({{ site.baseurl }}/galleries/messenger.html) to Mercury
+  * [Rosetta]({{ site.baseurl }}/galleries/rosetta.html) to 67P/Churyumov–Gerasimenko
 
 ## By Mission and System
 
-  * [Voyager at Jupiter](/galleries/voyager_jupiter.html)
-  * [Voyager at Saturn](/galleries/voyager_saturn.html)
-  * [Voyager at Uranus](/galleries/voyager_uranus.html)
-  * [Voyager at Neptune](/galleries/voyager_neptune.html)
-  * [Cassini at Jupiter](/galleries/cassini_jupiter.html)
-  * [Cassini at Saturn](/galleries/cassini_saturn.html)
+  * [Voyager at Jupiter]({{ site.baseurl }}/galleries/voyager_jupiter.html)
+  * [Voyager at Saturn]({{ site.baseurl }}/galleries/voyager_saturn.html)
+  * [Voyager at Uranus]({{ site.baseurl }}/galleries/voyager_uranus.html)
+  * [Voyager at Neptune]({{ site.baseurl }}/galleries/voyager_neptune.html)
+  * [Cassini at Jupiter]({{ site.baseurl }}/galleries/cassini_jupiter.html)
+  * [Cassini at Saturn]({{ site.baseurl }}/galleries/cassini_saturn.html)
 
 ## Omnibus - Every planetary press release from NASA
 
-  * [Everything](/galleries/all.html)
+  * [Everything]({{ site.baseurl }}/galleries/all.html)

--- a/website/hst/index.html
+++ b/website/hst/index.html
@@ -58,7 +58,7 @@ Directory names are in the form HST#x_xxxx, where # is replaced by a single
 letter that indicates which instrument obtained the data. We use the same
 letter identifiers for the instruments as STScI, "I" = WFC3; "J" = ACS; "U" =
 "WFPC2", "O" = STIS, "N" = NICMOS. These are available for directory tree browsing, or for downloading
-as separate [tar.gz](/help/targz.html) files for each "data set".
+as separate [tar.gz]({{ site.baseurl }}/help/targz.html) files for each "data set".
 
   * ACS -   [Browsable Volumes]({{ site.viewmaster_url }}volumes/HSTJx_xxxx/){:target="_blank"},    [downloadable tar.gz files]({{ site.viewmaster_url }}archives-volumes/HSTJx_xxxx/){:target="_blank"}
 
@@ -74,18 +74,18 @@ as separate [tar.gz](/help/targz.html) files for each "data set".
 
 The Ring-Moon Systems Node currently maintains two volumes of astrometric HST data for the small
 satellites of Saturn. For more information about and links to the data, see
-[Satellite Astrometry.](/astrometry/)
+[Satellite Astrometry.]({{ site.baseurl }}/astrometry/)
 
 ## Saturn Ring Plane Crossing (SRPX)
 
 The Ring-Moon Systems Node currently has nine volumes of SRPX data of which the first five
 volumes were obtained by the HST. For more information on the SRPX seasons,
 the information about and links to the associated data and links to relevant
-web sites, see [Saturn RPX.](/rpx/)
+web sites, see [Saturn RPX.]({{ site.baseurl }}/rpx/)
 
 ## Uranus Ring Plane Crossing (URPX)
 
 The Ring-Moon Systems Node currently has no data from the URPX observing campaign. We do
 anticipate receiving and archiving such data as it becomes available. For more
 information on the URPX seasons and links to relevant web sites, see [Uranian
-RPX.](/urpx/)
+RPX.]({{ site.baseurl }}/urpx/)

--- a/website/index.html
+++ b/website/index.html
@@ -30,7 +30,7 @@ homeboxes:
 
         + Drill down to individual products, complete with preview images, diagrams, indices, and documentation.
 
-        + Links to download [tar.gz]({{ site.baseurl }}/help/targz.html) archives of entire collections are never more than one click away.
+        + Links to download [tar.gz](/help/targz.html) archives of entire collections are never more than one click away.
 
       ***
 
@@ -68,16 +68,16 @@ homeboxes:
   - title: Juno Mission Tool Support
     content: >
 
-      **The RMS Node [Ephemeris Tools]({{ site.baseurl }}/tools)** now support the **Juno mission.**
+      **The RMS Node [Ephemeris Tools](/tools)** now support the **Juno mission.**
 
 
-      ![Animated Juno Viewer]({{ site.baseurl }}/viewer3_jup_18384_animated.gif "Animated Juno Viewer"){:.center-block}
+      ![Animated Juno Viewer](/viewer3_jup_18384_animated.gif "Animated Juno Viewer"){:.center-block}
 
-      + See the view from Juno at any point in time during the mission, past or future, with the [Jupiter Viewer]({{ site.baseurl }}/tools/viewer3_jupj.shtml).
+      + See the view from Juno at any point in time during the mission, past or future, with the [Jupiter Viewer](/tools/viewer3_jupj.shtml).
 
-      + Create tables of data for Jupiter and its moons with the [Ephemeris Generator]({{ site.baseurl }}/tools/ephem3_jupj.shtml).
+      + Create tables of data for Jupiter and its moons with the [Ephemeris Generator](/tools/ephem3_jupj.shtml).
 
-      + View the Juno Tools [here]({{ site.baseurl }}/tools/#juno "Juno Tools").
+      + View the Juno Tools [here](/tools/#juno "Juno Tools").
 
 
   - title: Help the RMS Node and PDS Serve You Better

--- a/website/index.html
+++ b/website/index.html
@@ -34,11 +34,11 @@ homeboxes:
 
       ***
 
-      **Browse** our PDS4 data holdings [by clicking here]({{ site.baseurl }}/pds4/bundles "PDS4 data holdings"){:target="_blank"}.
+      **Browse** our PDS4 data holdings [by clicking here](/pds4/bundles "PDS4 data holdings"){:target="_blank"}.
 
-        + Available tar.gz archives of PDS4 bundles are [here]({{ site.baseurl }}/pds4/archives-bundles "tar.gz archives of PDS4 bundles"){:target="_blank"}.
+        + Available tar.gz archives of PDS4 bundles are [here](/pds4/archives-bundles "tar.gz archives of PDS4 bundles"){:target="_blank"}.
 
-        + Applicable PDS4 schema are [here]({{ site.baseurl }}/pds4/schema "PDS4 schema"){:target="_blank"}.
+        + Applicable PDS4 schema are [here](/pds4/schema "PDS4 schema"){:target="_blank"}.
 
       ***
 
@@ -56,11 +56,11 @@ homeboxes:
   - title: Earth-Based Uranus System Stellar Occultations
     content: >
 
-        + We have archived more than 50 data bundles of [Earth-based observations of stellar occultations of the Uranus system]({{ site.baseurl }}/pds4/bundles/uranus_occs_earthbased/){:target="_blank"}.
+        + We have archived more than 50 data bundles of [Earth-based observations of stellar occultations of the Uranus system](/pds4/bundles/uranus_occs_earthbased/){:target="_blank"}.
 
         + Each bundle corresponds to a single occultation-telescope combination. These represent the highest quality observations spanning 25 years beginning with the ring system discovery observations by the Kuiper Airborne Observatory in 1977.
 
-        + Users are strongly encouraged to review the [associated support bundle]({{ site.baseurl }}/pds4/bundles/uranus_occs_earthbased/uranus_occ_support/){:target="_blank"} which includes a comprehensive Users Guide as well as models of the individual Uranian rings.
+        + Users are strongly encouraged to review the [associated support bundle](/pds4/bundles/uranus_occs_earthbased/uranus_occ_support/){:target="_blank"} which includes a comprehensive Users Guide as well as models of the individual Uranian rings.
 
         + To download the entire set in a single TAR.GZ file, [click here](//pds-rings.seti.org/pds4/archives-bundles/uranus_occs_earthbased "Uranus Occultations tar.gz file"){:target="_blank"}.
 

--- a/website/index.html
+++ b/website/index.html
@@ -30,15 +30,15 @@ homeboxes:
 
         + Drill down to individual products, complete with preview images, diagrams, indices, and documentation.
 
-        + Links to download [tar.gz](/help/targz.html) archives of entire collections are never more than one click away.
+        + Links to download [tar.gz]({{ site.baseurl }}/help/targz.html) archives of entire collections are never more than one click away.
 
       ***
 
-      **Browse** our PDS4 data holdings [by clicking here](/pds4/bundles "PDS4 data holdings"){:target="_blank"}.
+      **Browse** our PDS4 data holdings [by clicking here]({{ site.baseurl }}/pds4/bundles "PDS4 data holdings"){:target="_blank"}.
 
-        + Available tar.gz archives of PDS4 bundles are [here](/pds4/archives-bundles "tar.gz archives of PDS4 bundles"){:target="_blank"}.
+        + Available tar.gz archives of PDS4 bundles are [here]({{ site.baseurl }}/pds4/archives-bundles "tar.gz archives of PDS4 bundles"){:target="_blank"}.
 
-        + Applicable PDS4 schema are [here](/pds4/schema "PDS4 schema"){:target="_blank"}.
+        + Applicable PDS4 schema are [here]({{ site.baseurl }}/pds4/schema "PDS4 schema"){:target="_blank"}.
 
       ***
 
@@ -56,11 +56,11 @@ homeboxes:
   - title: Earth-Based Uranus System Stellar Occultations
     content: >
 
-        + We have archived more than 50 data bundles of [Earth-based observations of stellar occultations of the Uranus system](/pds4/bundles/uranus_occs_earthbased/){:target="_blank"}.
+        + We have archived more than 50 data bundles of [Earth-based observations of stellar occultations of the Uranus system]({{ site.baseurl }}/pds4/bundles/uranus_occs_earthbased/){:target="_blank"}.
 
         + Each bundle corresponds to a single occultation-telescope combination. These represent the highest quality observations spanning 25 years beginning with the ring system discovery observations by the Kuiper Airborne Observatory in 1977.
 
-        + Users are strongly encouraged to review the [associated support bundle](/pds4/bundles/uranus_occs_earthbased/uranus_occ_support/){:target="_blank"} which includes a comprehensive Users Guide as well as models of the individual Uranian rings.
+        + Users are strongly encouraged to review the [associated support bundle]({{ site.baseurl }}/pds4/bundles/uranus_occs_earthbased/uranus_occ_support/){:target="_blank"} which includes a comprehensive Users Guide as well as models of the individual Uranian rings.
 
         + To download the entire set in a single TAR.GZ file, [click here](//pds-rings.seti.org/pds4/archives-bundles/uranus_occs_earthbased "Uranus Occultations tar.gz file"){:target="_blank"}.
 
@@ -68,16 +68,16 @@ homeboxes:
   - title: Juno Mission Tool Support
     content: >
 
-      **The RMS Node [Ephemeris Tools](/tools)** now support the **Juno mission.**
+      **The RMS Node [Ephemeris Tools]({{ site.baseurl }}/tools)** now support the **Juno mission.**
 
 
-      ![Animated Juno Viewer](/viewer3_jup_18384_animated.gif "Animated Juno Viewer"){:.center-block}
+      ![Animated Juno Viewer]({{ site.baseurl }}/viewer3_jup_18384_animated.gif "Animated Juno Viewer"){:.center-block}
 
-      + See the view from Juno at any point in time during the mission, past or future, with the [Jupiter Viewer](/tools/viewer3_jupj.shtml).
+      + See the view from Juno at any point in time during the mission, past or future, with the [Jupiter Viewer]({{ site.baseurl }}/tools/viewer3_jupj.shtml).
 
-      + Create tables of data for Jupiter and its moons with the [Ephemeris Generator](/tools/ephem3_jupj.shtml).
+      + Create tables of data for Jupiter and its moons with the [Ephemeris Generator]({{ site.baseurl }}/tools/ephem3_jupj.shtml).
 
-      + View the Juno Tools [here](/tools/#juno "Juno Tools").
+      + View the Juno Tools [here]({{ site.baseurl }}/tools/#juno "Juno Tools").
 
 
   - title: Help the RMS Node and PDS Serve You Better

--- a/website/jupiter/index.html
+++ b/website/jupiter/index.html
@@ -13,11 +13,11 @@ title: "The Jupiter System"
   * Search for Jupiter system data in [OPUS]({{ site.opus_url }}/planet=Jupiter&widgets=planet,target){:target="_blank"}
   * Table of [ring information](jupiter_rings_table.html)
   * Table of [satellite information](jupiter_satellites_table.html)
-  * Outer planet [ephemeris tools](/tools/)
-  * Information about [Cassini](/cassini/) observations
-  * Information about [Galileo](/galileo/) observations
-  * Information about [Voyager](/voyager/) observations
-  * Information about [HST](/hst/) observations
+  * Outer planet [ephemeris tools]({{ site.baseurl }}/tools/)
+  * Information about [Cassini]({{ site.baseurl }}/cassini/) observations
+  * Information about [Galileo]({{ site.baseurl }}/galileo/) observations
+  * Information about [Voyager]({{ site.baseurl }}/voyager/) observations
+  * Information about [HST]({{ site.baseurl }}/hst/) observations
 
 ## Press Release Image Galleries
 

--- a/website/jupiter/index.html
+++ b/website/jupiter/index.html
@@ -24,8 +24,8 @@ title: "The Jupiter System"
   * Images from [Cassini]({{ site.assets_url }}galleries/cassini_jupiter.html)
   * Images from [Voyager]({{ site.assets_url }}galleries/voyager_jupiter.html)
   * Images from [Galileo]({{ site.assets_url }}galleries/galileo.html)
-  * Images from [New Horizons]({{ site.assets_url }}/galleries/new_horizons.html)
-  * Images from [Juno]({{ site.assets_url }}/galleries/juno.html)
+  * Images from [New Horizons]({{ site.assets_url }}galleries/new_horizons.html)
+  * Images from [Juno]({{ site.assets_url }}galleries/juno.html)
   * All NASA press releases about the [Jupiter system]({{ site.assets_url }}galleries/target_jupiter.html)
 
 ## Related Web Sites

--- a/website/neptune/index.html
+++ b/website/neptune/index.html
@@ -15,14 +15,14 @@ Image credit: NASA, ESA, and M. Showalter (SETI Institute)
   * Search for Neptune system data in [OPUS]({{ site.opus_url }}/planet=Neptune&widgets=planet,target){:target="_blank"}
   * Table of [ring information](neptune_rings_table.html)
   * Table of [satellite information](neptune_satellites_table.html)
-  * Outer planet [ephemeris tools](/tools/)
-  * Information about [Voyager](/voyager/) observations
-  * Information about [HST](/hst/) observations
+  * Outer planet [ephemeris tools]({{ site.baseurl }}/tools/)
+  * Information about [Voyager]({{ site.baseurl }}/voyager/) observations
+  * Information about [HST]({{ site.baseurl }}/hst/) observations
 
 ## Press Release Image Galleries
 
-  * Images from [Voyager](/galleries/voyager_neptune.html)
-  * All NASA press releases about the [Neptune system](/galleries/target_neptune.html)
+  * Images from [Voyager]({{ site.baseurl }}/galleries/voyager_neptune.html)
+  * All NASA press releases about the [Neptune system]({{ site.baseurl }}/galleries/target_neptune.html)
   * Images from the Hubble Space Telescope (in progress)
 
 ## Related Web Sites

--- a/website/newhorizons/access.html
+++ b/website/newhorizons/access.html
@@ -22,7 +22,7 @@ post launch cruise, the Jupiter encounter, Pluto cruise, and the Pluto encounter
 
   * **Download** an entire volume, by right clicking on that volume's "Bundled" link in the second table.
 
-The bundled volumes are provided in [tar.gz](/help/targz.html) format.
+The bundled volumes are provided in [tar.gz]({{ site.baseurl }}/help/targz.html) format.
 
   * **Browse** will take you to a directory containing sub-directories of preview images for each data product in the volume.
 
@@ -45,7 +45,7 @@ The bundled volumes are provided in [tar.gz](/help/targz.html) format.
 
 ## Available Volumes
 
-  * To determine which volumes meet the publicly available criteria for a specific ROSES Announcement please see the appropriate DAP page under our [Proposal Support](/roses) pages.
+  * To determine which volumes meet the publicly available criteria for a specific ROSES Announcement please see the appropriate DAP page under our [Proposal Support]({{ site.baseurl }}/roses) pages.
 
 {% assign table_name = "New Horizons LORRI and MVIC Releases" %}
 {% assign table_desc = "A listing of New Horizons LORRI and MVIC Releases" %}

--- a/website/pluto/index.html
+++ b/website/pluto/index.html
@@ -12,9 +12,9 @@ title: "The Pluto System"
 
   * Search for Pluto system data in [OPUS]({{ site.opus_url }}/planet=Pluto&widgets=planet,target){:target="_blank"}
   * Table of [satellite information](pluto_tables.html)
-  * Outer planet [ephemeris tools](/tools/)
-  * Information about [New Horizons](/newhorizons/) observations
-  * Information about [HST](/hst/) observations
+  * Outer planet [ephemeris tools]({{ site.baseurl }}/tools/)
+  * Information about [New Horizons]({{ site.baseurl }}/newhorizons/) observations
+  * Information about [HST]({{ site.baseurl }}/hst/) observations
 
 ## Press Release Image Galleries
 

--- a/website/resonance/index.html
+++ b/website/resonance/index.html
@@ -22,8 +22,8 @@ are sorted by order (lowest order first) and then by semi-major axis.
 For more information on the tables and the input parameters used to generate
 them, see the file [saturn_resonances.pdf]({{ site.holdings_url }}volumes/RES_xxxx_prelim/RES_0001/document/saturn_resonances.pdf){:target="_blank"}.
 
-**NOTE**: The links on this page are to a preliminary data set which has not undergone peer review. 
+**NOTE**: The links on this page are to a preliminary data set which has not undergone peer review.
 
-  * To browse the dataset, click [here]({{ site.viewmaster_url }}volumes/RES_xxxx_prelim/RES_0001/){:target="_blank"}. 
+  * To browse the dataset, click [here]({{ site.viewmaster_url }}volumes/RES_xxxx_prelim/RES_0001/){:target="_blank"}.
 
-  * To download the entire dataset bundled in a [tar.gz](/help/targz.html) file, click [here]({{ site.holdings_url }}archives-volumes/RES_xxxx_prelim/RES_0001.tar.gz). 
+  * To download the entire dataset bundled in a [tar.gz]({{ site.baseurl }}/help/targz.html) file, click [here]({{ site.holdings_url }}archives-volumes/RES_xxxx_prelim/RES_0001.tar.gz).

--- a/website/ringocc/index.html
+++ b/website/ringocc/index.html
@@ -18,7 +18,7 @@ All three Cassini Ring Occultation datasets have been updated to version 2. Here
   * **UVIS version 2** \- Browse the data set on-line [COUVIS_8001]({{ site.viewmaster_url }}volumes/COUVIS_8xxx/COUVIS_8001/){:target="_blank"}, or download the entire data set [COUVIS_8001 tar.gz](/link/archives-volumes/COUVIS_8xxx/COUVIS_8001.tar.gz) (438 MB).
   * **VIMS version 2** \- Browse the data set on-line [COVIMS_8001]({{ site.viewmaster_url }}volumes/COVIMS_8xxx/COVIMS_8001/){:target="_blank"}, or download the entire data set [COVIMS_8001 tar.gz](/link/archives-volumes/COVIMS_8xxx/COVIMS_8001.tar.gz) (320 MB).
 
-Details about each of the instruments are available from our [Cassini information pages](/cassini/).
+Details about each of the instruments are available from our [Cassini information pages]({{ site.baseurl }}/cassini/).
 
 **5/3/19 Versions 2 of the UVIS dataset [COUVIS_8001]({{ site.viewmaster_url }}volumes/COUVIS_8xxx/COUVIS_8001/){:target="_blank"}
 	and the VIMS dataset [COVIMS_8001]({{ site.viewmaster_url }}volumes/COVIMS_8xxx/COVIMS_8001/){:target="_blank"} are available online.**
@@ -79,21 +79,21 @@ generated from the finest resolution Voyager ISS images.
   PDS currently does not have a copy of the original raw data files for the Voyager 2 RSS Uranus ring system occultation.
 
 Details about each of the instruments are available from our [Voyager
-information pages](/voyager/).
+information pages]({{ site.baseurl }}/voyager/).
 
 # Earth-Based Occultations
 
 ## Uranus Rings and Atmospheres
 
 We have archived more than 50 data bundles of
-[Earth-based observations of stellar occultations of the Uranus system](/pds4/bundles/uranus_occs_earthbased/){:target="_blank"}.
+[Earth-based observations of stellar occultations of the Uranus system]({{ site.baseurl }}/pds4/bundles/uranus_occs_earthbased/){:target="_blank"}.
 
 Each bundle corresponds to a single occultation-telescope combination. These
 represent the highest quality observations spanning 25 years beginning with the
 ring system discovery observations by the Kuiper Airborne Observatory in 1977.
 
 Users are strongly encouraged to review the
-[associated support bundle](/pds4/bundles/uranus_occs_earthbased/uranus_occ_support/){:target="_blank"}
+[associated support bundle]({{ site.baseurl }}/pds4/bundles/uranus_occs_earthbased/uranus_occ_support/){:target="_blank"}
 which includes a comprehensive Users Guide as well as models of the individual
 Uranian rings.
 

--- a/website/ringocc/index.html
+++ b/website/ringocc/index.html
@@ -86,14 +86,14 @@ information pages]({{ site.baseurl }}/voyager/).
 ## Uranus Rings and Atmospheres
 
 We have archived more than 50 data bundles of
-[Earth-based observations of stellar occultations of the Uranus system]({{ site.baseurl }}/pds4/bundles/uranus_occs_earthbased/){:target="_blank"}.
+[Earth-based observations of stellar occultations of the Uranus system](/pds4/bundles/uranus_occs_earthbased/){:target="_blank"}.
 
 Each bundle corresponds to a single occultation-telescope combination. These
 represent the highest quality observations spanning 25 years beginning with the
 ring system discovery observations by the Kuiper Airborne Observatory in 1977.
 
 Users are strongly encouraged to review the
-[associated support bundle]({{ site.baseurl }}/pds4/bundles/uranus_occs_earthbased/uranus_occ_support/){:target="_blank"}
+[associated support bundle](/pds4/bundles/uranus_occs_earthbased/uranus_occ_support/){:target="_blank"}
 which includes a comprehensive Users Guide as well as models of the individual
 Uranian rings.
 

--- a/website/roses/2013/cdaps.html
+++ b/website/roses/2013/cdaps.html
@@ -19,57 +19,57 @@ redirect_from:
 
 <h3>Data Sources</h3>
 
-<p> The Cassini Data Analysis and Participating Scientists Program (CDAPS) 
+<p> The Cassini Data Analysis and Participating Scientists Program (CDAPS)
       is described in Appendix C.10 of the ROSES 2013 NRA.
-    The full document can be accessed under <b>Solicitations</b> at the 
-    <a href="//nspires.nasaprs.com/external/">NSPIRES web site.</a> 
+    The full document can be accessed under <b>Solicitations</b> at the
+    <a href="//nspires.nasaprs.com/external/">NSPIRES web site.</a>
 </p>
 
  <p>
- <p>The specific data restrictions given for the 2013 
-    CDAPS are: 
- </p> 
- 
-  <ul> 
-        
-  <p>Proposals must be focused on the Saturn system and make 
-   significant use of (or greatly enhance the use of) data 
-   returned by Cassini instruments. Proposals to work with Cassini 
-   data and also use ground-based or other data are acceptable, 
-   provided that the success of the proposal, as written, is 
-   dependent upon the Cassini data. 
+ <p>The specific data restrictions given for the 2013
+    CDAPS are:
+ </p>
+
+  <ul>
+
+  <p>Proposals must be focused on the Saturn system and make
+   significant use of (or greatly enhance the use of) data
+   returned by Cassini instruments. Proposals to work with Cassini
+   data and also use ground-based or other data are acceptable,
+   provided that the success of the proposal, as written, is
+   dependent upon the Cassini data.
   </p>
- 
-  <p>In the first two years of the CDAPS program data from the 
-   Cassini Jupiter flyby in 2000 were eligible. This is no longer 
-   true. Proposals that address Jupiter data should be directed to 
-   the Outer Planets Research program described in Appendix C.7 of 
+
+  <p>In the first two years of the CDAPS program data from the
+   Cassini Jupiter flyby in 2000 were eligible. This is no longer
+   true. Proposals that address Jupiter data should be directed to
+   the Outer Planets Research program described in Appendix C.7 of
    this ROSES NRA.
   </p>
-  
-   <p>In order to be considered under the data analysis portion of 
-    the call, proposing PIs <b>must use data that are in the 
-    public domain 90 days before the CDAPS Step 2 proposals due 
-    date</b>, and they must 
-    make clear to the peer reviewers that the data are publicly 
-    available. Proposals that do not comply with this rule may be 
-    declared noncompliant and declined without evaluation. It is 
-    understood, however, that once the grant is awarded, 
-    succeeding years of work may address data that have 
-    subsequently come into the archive. 
-   </p>  
-  
-   <p>Whether from the PDS or another source, if the data to be 
-    analyzed is not certified or otherwise has issues that might 
-    represent an obstacle to analysis, the proposers must clearly 
-    demonstrate that such potential difficulties can be overcome. 
+
+   <p>In order to be considered under the data analysis portion of
+    the call, proposing PIs <b>must use data that are in the
+    public domain 90 days before the CDAPS Step 2 proposals due
+    date</b>, and they must
+    make clear to the peer reviewers that the data are publicly
+    available. Proposals that do not comply with this rule may be
+    declared noncompliant and declined without evaluation. It is
+    understood, however, that once the grant is awarded,
+    succeeding years of work may address data that have
+    subsequently come into the archive.
+   </p>
+
+   <p>Whether from the PDS or another source, if the data to be
+    analyzed is not certified or otherwise has issues that might
+    represent an obstacle to analysis, the proposers must clearly
+    demonstrate that such potential difficulties can be overcome.
    </p>
   </ul>
 
- <p><b> Volumes at the Ring-Moon Systems Node</b> which meet the CDAPS basic 
-  eligibility requirements for publicly available timing (based on 
-  the Step 2 Proposal due date)and PDS certification are listed 
-  below. 
+ <p><b> Volumes at the Ring-Moon Systems Node</b> which meet the CDAPS basic
+  eligibility requirements for publicly available timing (based on
+  the Step 2 Proposal due date)and PDS certification are listed
+  below.
  </p>
  <ul>
    <li>COCIRS_0401 through COCIRS_1203</li>
@@ -81,9 +81,9 @@ redirect_from:
    <li>COVIMS_0004 through COVIMS_0051</li>
  </ul>
 
-<p>In addition, Volumes <b>at the Ring-Moon Systems Node</b> which meet the CDAPS 
-  basic eligibility requirements for publicly available timing but which 
-  <b>have not</b> yet been certified by PDS are: 
+<p>In addition, Volumes <b>at the Ring-Moon Systems Node</b> which meet the CDAPS
+  basic eligibility requirements for publicly available timing but which
+  <b>have not</b> yet been certified by PDS are:
 </p>
  <ul>
     <li>CORSS_8001</li>
@@ -91,30 +91,30 @@ redirect_from:
     <li>COVIMS_8001</li>
  </ul>
 </ul>
- 
+
 <h3>Finding Cassini Data within the PDS</h3>
 
 <b> Data at the Ring-Moon Systems Node.</b>
 
  <ul>
     <li><b> Search for data</b></li>
-    
-  <p> [OPUS](/search/), our Outer Planets Unified 
-   Search tool, allows users to search for and obtain subsets of 
-   data based on a wide range of constraints. OPUS supports Saturn system 
-   data obtained by Cassini CIRS prior to July 2010, and all Saturn system 
+
+  <p> [OPUS]({{ site.baseurl }}/search/), our Outer Planets Unified
+   Search tool, allows users to search for and obtain subsets of
+   data based on a wide range of constraints. OPUS supports Saturn system
+   data obtained by Cassini CIRS prior to July 2010, and all Saturn system
    observations currently available in PDS obtained by Cassini ISS, UVIS and
-   VIMS, as well as data sets obtained by other missions including Voyager. 
+   VIMS, as well as data sets obtained by other missions including Voyager.
    Search results include preview images for all observations.</p>
- 
- <p><b>For Cassini ISS, UVIS, and VIMS, the OPUS search parameters are based on 
-    enhanced geometric metadata generated at the rings node and include constraints 
-relating to the surfaces of the planet and satellites as well as to the rings.</b> 
+
+ <p><b>For Cassini ISS, UVIS, and VIMS, the OPUS search parameters are based on
+    enhanced geometric metadata generated at the rings node and include constraints
+relating to the surfaces of the planet and satellites as well as to the rings.</b>
      </p>
-      
+
     <li><b> Use our Cassini Information Pages</b></li>
-  <p> Our [Cassini information pages](/cassini/) provide:
-    <ul> 
+  <p> Our [Cassini information pages]({{ site.baseurl }}/cassini/) provide:
+    <ul>
       <li>tabular links to the data organized by observation date for each instrument,</li>
       <li>links to Ring-Moon Systems Node generated preview images (ISS, UVIS and VIMS) and footprint diagrams (CIRS), </li>
       <li>links to tables of enhanced geometric metadata, </li>
@@ -123,21 +123,21 @@ relating to the surfaces of the planet and satellites as well as to the rings.</
   </ul>
   </p>
   <p><li><b>Browse</b> our [data directories](/link/volumes/) </li></p>
-  
-  <p><li><b>Download</b> [entire volumes](/link/volumes/) as [tar.gz](/help/targz.html) files.</li></p>
+
+  <p><li><b>Download</b> [entire volumes](/link/volumes/) as [tar.gz]({{ site.baseurl }}/help/targz.html) files.</li></p>
 
 
 </ul>
 
 <b> Other PDS Resources</b>
- 
+
  <ul>
 
   <li><b>Other PDS Discipline Node Cassini Pages.</b></li>
 
   <ul>
     <li><a href="//pds-atmospheres.nmsu.edu/data_and_services/atmospheres_data/Cassini/Cassini.html">Atmospheres Node</a></li>
-    <li><a href="//pds-imaging.jpl.nasa.gov/portal/cassini_mission.html">Imaging Node</a></li>    
+    <li><a href="//pds-imaging.jpl.nasa.gov/portal/cassini_mission.html">Imaging Node</a></li>
     <li><a href="//pds-ppi.igpp.ucla.edu/search/?s=Cassini%20Orbiter">Planetary Plasma Interactions Node (PPI)</a></li>
     <li><a href="/cassini/">Ring-Moon Systems Node </a></li>
     <li><a href="//pds-smallbodies.astro.umd.edu/data_sb/missions/cassini/index.shtml">Small Bodies Node (SBN)</a></li>
@@ -147,26 +147,22 @@ relating to the surfaces of the planet and satellites as well as to the rings.</
 
   <li><b> The PDS NAIF Node and observation geometry.</b></li>
 
-  <p>SPICE data and software may be obtained from the  
-    <a href="//naif.jpl.nasa.gov/naif/">NAIF web site</a>.SPICE 
-   data files contain spacecraft and solar system geometry data 
-   necessary to interpret scientific observations from space-based 
-   instruments. The SPICE system also includes a large suite of 
-   software, mostly in the form of subroutines, that users 
-   incorporate in their own application programs to read SPICE 
-   files and to compute derived observation geometry, such as 
-   altitude, latitude/longitude, and lighting angles. 
+  <p>SPICE data and software may be obtained from the
+    <a href="//naif.jpl.nasa.gov/naif/">NAIF web site</a>.SPICE
+   data files contain spacecraft and solar system geometry data
+   necessary to interpret scientific observations from space-based
+   instruments. The SPICE system also includes a large suite of
+   software, mostly in the form of subroutines, that users
+   incorporate in their own application programs to read SPICE
+   files and to compute derived observation geometry, such as
+   altitude, latitude/longitude, and lighting angles.
   </p>
 </ul>
 
 </ul>
- 
+
 
 <br>
 <hr>
 <a href="/roses/">ROSES Support Home</a> |
 <a href="/">Ring-Moon Systems Node Home</a>
-
-
-
-

--- a/website/roses/2013/index.html
+++ b/website/roses/2013/index.html
@@ -50,23 +50,23 @@ site.</a>
 The links in the following table are to the respective Ring-Moon Systems Node support
 pages (same destinations as the tabs at the top of the page).
 
-Program | Appendix | NOI Due | Proposal Due  
----|---|---|---  
-[Cassini Data Analysis and Participating Scientists Program (CDAPS)](cdaps.html) | C.10 | 3/26/13* | 5/3/13  
-[Outer Planets Research (OPR)](opr.html) | C.7 | 8/23/13 | 11/15/13  
-[Planetary Geology and Geophysics (PG&amp;G;)(pgg.html) | C.4 | 5/3/13 | 6/14/13  
-[Planetary Mission DAP (PMDAP)**](pmdap.html) | C.11 | 8/16/13 | 10/28/13  
-  
+Program | Appendix | NOI Due | Proposal Due
+---|---|---|---
+[Cassini Data Analysis and Participating Scientists Program (CDAPS)](cdaps.html) | C.10 | 3/26/13* | 5/3/13
+[Outer Planets Research (OPR)](opr.html) | C.7 | 8/23/13 | 11/15/13
+[Planetary Geology and Geophysics (PG&amp;G;)(pgg.html) | C.4 | 5/3/13 | 6/14/13
+[Planetary Mission DAP (PMDAP)**](pmdap.html) | C.11 | 8/16/13 | 10/28/13
 
-* **CDAPS**. 
 
-**The Notice of Intent is replaced by a required Step-1 proposal. The Title and Team provided in Step-1 cannot change.**. The three page Step-1 proposal will be used to conduct a preliminary evaluation, which will result in full proposals being either encouraged or discouraged. 
+* **CDAPS**.
 
-** **PMDAP**. 
+**The Notice of Intent is replaced by a required Step-1 proposal. The Title and Team provided in Step-1 cannot change.**. The three page Step-1 proposal will be used to conduct a preliminary evaluation, which will result in full proposals being either encouraged or discouraged.
+
+** **PMDAP**.
 
 PMDAP affords a unique opportunity for ring scientists to propose for the
 restoration of publicly available data sets. Individuals or teams interested
-in pursuing this opportunity should [ contact us](/cgi-bin/comments/form.pl)
+in pursuing this opportunity should [ contact us]({{ site.baseurl }}/cgi-bin/comments/form.pl)
 early for assistance in identifying and obtaining eligible data, and in
 determining the PDS compliance requirements for the completed deliverables.
 
@@ -75,4 +75,3 @@ determining the PDS compliance requirements for the completed deliverables.
 Links to ROSES support pages at the other PDS Nodes can be found at the PDS
 Engineering Node's <a href="//pds.nasa.gov/ROSES/roses.shtml" target="_blank">ROSES support</a>
 page.
-

--- a/website/roses/2013/opr.html
+++ b/website/roses/2013/opr.html
@@ -21,8 +21,8 @@ redirect_from:
 <h3>Data Sources</h3>
 
 <p> The Outer Planets Research (OPR) program is described in Appendix C.7 of the NRA.
-    The full document can be accessed under <b>Solicitations</b> at the 
-    <a href="//nspires.nasaprs.com/external/">NSPIRES web site.</a> 
+    The full document can be accessed under <b>Solicitations</b> at the
+    <a href="//nspires.nasaprs.com/external/">NSPIRES web site.</a>
 </p>
 
 <p>The specific data availability restrictions given for the 2013 OPR are:
@@ -30,25 +30,25 @@ redirect_from:
 
  <ul>
 
-   <p> "It is the responsibility of the investigators selected for 
-   this program to acquire any needed data. Therefore, before 
-   submitting a proposal, the investigator must determine that all 
-   data required for the proposed investigation are publicly 
-   available <b>[by the proposal due date]</b>. Proposals requiring 
-    the use of data that are not 
-   publicly available at the time of proposal submission may be 
+   <p> "It is the responsibility of the investigators selected for
+   this program to acquire any needed data. Therefore, before
+   submitting a proposal, the investigator must determine that all
+   data required for the proposed investigation are publicly
+   available <b>[by the proposal due date]</b>. Proposals requiring
+    the use of data that are not
+   publicly available at the time of proposal submission may be
    rejected without review."
  </p>
 
- <p> "Proposals dealing with mission data should provide convincing evidence 
-  that currently available public data has sufficient quality and is 
-  available in sufficient quantity to achieve the goals set forth in 
+ <p> "Proposals dealing with mission data should provide convincing evidence
+  that currently available public data has sufficient quality and is
+  available in sufficient quantity to achieve the goals set forth in
   the proposal."
  </p>
  </ul>
 
-<p> <b> AS of 6/18/2013, volumes at the Ring-Moon Systems Node</b> which meet the 
-  OPR basic eligibility requirements for <b>publicly available timing and 
+<p> <b> AS of 6/18/2013, volumes at the Ring-Moon Systems Node</b> which meet the
+  OPR basic eligibility requirements for <b>publicly available timing and
   PDS certification</b> are listed below. </p>
  <ul>
     <li>ASTROM_nnnn</li>
@@ -61,7 +61,7 @@ redirect_from:
     <li>COUVIS 0001 through 0039</li>
     <li>COVIMS 0001 through 0052</li>
     <li>EBROCC_0001</li>
-    <li>GO_0017 through 0023</li> 
+    <li>GO_0017 through 0023</li>
     <li>HSTJ0_9296 through HSTJ1_2003</li>
     <li>HSTU0_5167 through HSTU1_1956</li>
     <li>NHJULO_1001 through NHJULO_2003</li>
@@ -73,18 +73,18 @@ redirect_from:
     <li>VGISS_6101 through VGISS_6215 (Saturn)</li>
  </ul>
 
-<p>In addition, the following Volumes <b>at the Ring-Moon Systems Node</b> meet the OPR 
-  basic eligibility requirements for publicly available timing, but <b>are not 
-  yet certified by PDS</b>. However, 
-  for some proposals it may be possible to demonstrate that the "...data has 
-  sufficient quality and is available in sufficient quantity to achieve the 
+<p>In addition, the following Volumes <b>at the Ring-Moon Systems Node</b> meet the OPR
+  basic eligibility requirements for publicly available timing, but <b>are not
+  yet certified by PDS</b>. However,
+  for some proposals it may be possible to demonstrate that the "...data has
+  sufficient quality and is available in sufficient quantity to achieve the
   goals set forth in the proposal."
 </p>
-<p> Proposers considering using any of the following should  
-      [contact us](/cgi-bin/comments/form.pl) early to discuss the 
+<p> Proposers considering using any of the following should
+      [contact us]({{ site.baseurl }}/cgi-bin/comments/form.pl) early to discuss the
       suitability of specific volumes for their planned research.
-</p> 
-    
+</p>
+
  </p>
  <ul>
     <li>CORSS_8001</li>
@@ -93,7 +93,7 @@ redirect_from:
     <li>HSTJx_xxxx</li>
     <li>HSTUx_xxxx</li>
   <li>RES_0001</li>
-  <li>VG_2803</li>  
+  <li>VG_2803</li>
   <li>VGIRIS_0001 through 0002</li>
   <li>VGISS_5101 through 5214</li> (Jupiter)
   <li>VGISS_7201 through 7207</li> (Uranus)
@@ -104,86 +104,86 @@ redirect_from:
 
 <b> Data at the Ring-Moon Systems Node.</b>
 
- <ul> 
+ <ul>
     <li><b> Search for data</b></li>
-    
-   <p>[OPUS](/search/), our Outer Planets Unified 
-   Search tool, allows users to search for and obtain subsets of 
-   data based on a wide range of constraints. OPUS supports Cassini 
-   CIRS, ISS, UVIS and VIMS data, New Horizons 
-   Jupiter LORRI data, Galileo SSI data, and Voyager ISS data. 
+
+   <p>[OPUS]({{ site.baseurl }}/search/), our Outer Planets Unified
+   Search tool, allows users to search for and obtain subsets of
+   data based on a wide range of constraints. OPUS supports Cassini
+   CIRS, ISS, UVIS and VIMS data, New Horizons
+   Jupiter LORRI data, Galileo SSI data, and Voyager ISS data.
    The results returned include preview products and tables of metadata.</p>
 
 
   <p><li><b>Browse</b> our [data directories](/link/volumes/) </li></p>
-  
-  <p><li><b>Download</b> [entire volumes](/link/archives-volumes/) as [tar.gz](/help/targz.html) files.</li></p>
 
-  
+  <p><li><b>Download</b> [entire volumes](/link/archives-volumes/) as [tar.gz]({{ site.baseurl }}/help/targz.html) files.</li></p>
+
+
     <li><b> Use our Mission Information Pages</b></li>
-    
- <p>Our mission information pages provide overviews of data sets and instruments along with 
-    links to detailed descriptions of the instruments and to the data 
+
+ <p>Our mission information pages provide overviews of data sets and instruments along with
+    links to detailed descriptions of the instruments and to the data
     and to Ring-Moon Systems Node generated browse images and footprint diagrams.</p>
-  
-  <ul> 
-   <p><li>[Cassini](/cassini/) Our Cassini mission pages support CIRS, 
+
+  <ul>
+   <p><li>[Cassini]({{ site.baseurl }}/cassini/) Our Cassini mission pages support CIRS,
     ISS, UVIS, and VIMS, including links to updated geometric metadata
-        for these four instruments, plus occultation data obtained by RSS, UVS & VIMS, 
+        for these four instruments, plus occultation data obtained by RSS, UVS & VIMS,
         and links to calibrated ISS images. </li>
    </p>
-    
-  <p><li>[New Horizons](/newhorizons/). Our New Horizon page
+
+  <p><li>[New Horizons]({{ site.baseurl }}/newhorizons/). Our New Horizon page
      provides access to the full set of LORRI Jupiter data and SPICE files, browse images
-     for the LORRI data, and links to the full New Horizons Jupiter data collection at the 
+     for the LORRI data, and links to the full New Horizons Jupiter data collection at the
      Small Bodies Node.</li>
     </p>
-                 
-  <p><li><a href="/galileo/">Galileo. </a>Our Galileo page supports the Solid State 
+
+  <p><li><a href="/galileo/">Galileo. </a>Our Galileo page supports the Solid State
     Imager (SSI) and the Near-Infrared Mapping Spectrometer (NIMS).  </li>
     </p>
-    
-  <p><li><a href="/voyager/">Voyager. </a> Our Voyager pages 
-   support ISS including new data sets of uncompressed, calibrated 
-   and geometrically corrected images, IRIS, and occultation data 
-   from PPS, UVS, and RSS. These pages also provide access to the 
+
+  <p><li><a href="/voyager/">Voyager. </a> Our Voyager pages
+   support ISS including new data sets of uncompressed, calibrated
+   and geometrically corrected images, IRIS, and occultation data
+   from PPS, UVS, and RSS. These pages also provide access to the
    Voyager SPICE kernels generated at the Ring-Moon Systems Node.</li>
   </p>
-    
-  <p><li><a href="/urpx/">Uranus Ring Plane Crossing </a>. While 
-   publicly available URPX observations obtained under Planetary 
-   Astronomy Program are covered by this NRA, we do not currently 
-   have any such data. If eligible URPX data becomes available at 
-   the Ring's Node prior to the proposal deadline, this page will 
+
+  <p><li><a href="/urpx/">Uranus Ring Plane Crossing </a>. While
+   publicly available URPX observations obtained under Planetary
+   Astronomy Program are covered by this NRA, we do not currently
+   have any such data. If eligible URPX data becomes available at
+   the Ring's Node prior to the proposal deadline, this page will
    reflect it. </li>
   </p>
- 
+
   </ul>
  </ul>
 
 <b> Data available at other PDS nodes.</b>
- <ul>  
+ <ul>
   <li><b> The PDS NAIF Node and observation geometry.</b></li>
 
-  <p>SPICE data and software may be obtained from the  
-    <a href="//naif.jpl.nasa.gov/naif/">NAIF web site</a>.SPICE 
-   data files contain spacecraft and solar system geometry data 
-   necessary to interpret scientific observations from space-based 
-   instruments. The SPICE system also includes a large suite of 
-   software, mostly in the form of subroutines, that users 
-   incorporate in their own application programs to read SPICE 
-   files and to compute derived observation geometry, such as 
-   altitude, latitude/longitude, and lighting angles. 
+  <p>SPICE data and software may be obtained from the
+    <a href="//naif.jpl.nasa.gov/naif/">NAIF web site</a>.SPICE
+   data files contain spacecraft and solar system geometry data
+   necessary to interpret scientific observations from space-based
+   instruments. The SPICE system also includes a large suite of
+   software, mostly in the form of subroutines, that users
+   incorporate in their own application programs to read SPICE
+   files and to compute derived observation geometry, such as
+   altitude, latitude/longitude, and lighting angles.
    </p>
 
-<p><li>Links to ROSES support pages at the other PDS Nodes can be found at 
-    the PDS Engineering Node's 
+<p><li>Links to ROSES support pages at the other PDS Nodes can be found at
+    the PDS Engineering Node's
 <a href="//pds.nasa.gov/ROSES/roses.shtml"> ROSES support</a> page.</li>
 </p>
 
- <li>For PDS wide search, start with the 
-    <a href="//pds.nasa.gov/tools/data-search/">PDS wide search engine</a>. 
-    This search capability is limited, but initial results include links to relevant and much more 
+ <li>For PDS wide search, start with the
+    <a href="//pds.nasa.gov/tools/data-search/">PDS wide search engine</a>.
+    This search capability is limited, but initial results include links to relevant and much more
     powerful discipline node search engines. </li>
 </ul>
 
@@ -193,8 +193,3 @@ redirect_from:
 <hr>
 <a href="/roses/">ROSES Support Home</a> |
 <a href="/">Ring-Moon Systems Node Home</a>
-
-
-
-
-

--- a/website/roses/2014/index.html
+++ b/website/roses/2014/index.html
@@ -5,7 +5,7 @@ tabs: roses_2014
 redirect_from:
   - /roses/index_2014.html
 ---
-  
+
 ## Welcome to the Ring-Moon Systems Node's ROSES 2014 NRA Support Pages
 
 **Latest update:** 6/23/14 - through Amendment 24.
@@ -32,9 +32,9 @@ submission across all of the programs.
 See the full NRA for complete details and restrictions.
 
   * For proposals that contain mission data analysis, planetary spacecraft mission data to be used in proposed investigations must be available in the Planetary Data System (PDS) or equivalent publicly accessible archive at least 30 days prior to the Step 2 proposal submission date.
-    * See the "Data Status" tab for the availability date and "PDS Certification" status of each of the data sets or data volumes in the Ring-Moon Systems Node holdings. 
+    * See the "Data Status" tab for the availability date and "PDS Certification" status of each of the data sets or data volumes in the Ring-Moon Systems Node holdings.
 
-  * Requirements for depositing derived data products in the Planetary Data System have been revised to require that all products be PDS4 conformant. Guidelines for planning data in this format are available at  Archiving under PDS4. 
+  * Requirements for depositing derived data products in the Planetary Data System have been revised to require that all products be PDS4 conformant. Guidelines for planning data in this format are available at  Archiving under PDS4.
 
 The other tabs associated with this page provide information on data at the
 the Ring-Moon Systems Node relevant to the specific AO identified in the tab name.
@@ -50,12 +50,12 @@ site.</a>
 The links in the following table are to the respective Ring-Moon Systems Node support
 pages (same destinations as the tabs at the top of the page).
 
-Program | Appendix | Step 1 Proposal Due | Step 2 Proposal Due  
----|---|---|---  
-[Cassini Data Analysis and Participating Scientists Program (CDAPS)](cdaps.html) | C.10 | 7/28/14 | 9/26/14  
-[Planetary Data Archiving, Restoration, and Tools (PDART)](pdart.html) | C.7 | 7/17/14 | 9/17/14  
-[Solar System Workings (SSW)](ssw.html) | C.3 | 5/23/14 | 7/25/14  
-  
+Program | Appendix | Step 1 Proposal Due | Step 2 Proposal Due
+---|---|---|---
+[Cassini Data Analysis and Participating Scientists Program (CDAPS)](cdaps.html) | C.10 | 7/28/14 | 9/26/14
+[Planetary Data Archiving, Restoration, and Tools (PDART)](pdart.html) | C.7 | 7/17/14 | 9/17/14
+[Solar System Workings (SSW)](ssw.html) | C.3 | 5/23/14 | 7/25/14
+
 
 ### Additional PDS Support
 
@@ -64,5 +64,4 @@ Links to ROSES support pages at the other PDS Nodes can be found at the PDS
 Engineering Node's <a href="//pds.nasa.gov/ROSES/roses.shtml" target="_blank">ROSES support</a>
 page.
 
-The Ring-Moon Systems Node's [ ROSES 2013](/roses/2013/index.html) support page.
-
+The Ring-Moon Systems Node's [ ROSES 2013]({{ site.baseurl }}/roses/2013/index.html) support page.

--- a/website/roses/2015/index.html
+++ b/website/roses/2015/index.html
@@ -28,11 +28,11 @@ page.
 See the full NRA for complete details and restrictions.
 
   * For proposals that contain mission data analysis, planetary spacecraft mission data to be used in proposed investigations must be available in the Planetary Data System (PDS) or equivalent publicly accessible archive at least 30 days prior to the Step 2 proposal submission date.
-    * See the "Data Status" tab for the availability date and "PDS Certification" status of each of the data sets or data volumes in the Ring-Moon Systems Node holdings. 
+    * See the "Data Status" tab for the availability date and "PDS Certification" status of each of the data sets or data volumes in the Ring-Moon Systems Node holdings.
 
-  * Proposals submitted to ROSES-2015 are required to include a data management plan (DMP), unless explicitly noted by the specific program element. 
+  * Proposals submitted to ROSES-2015 are required to include a data management plan (DMP), unless explicitly noted by the specific program element.
 
-    * Guidelines for preparing PDS4 compliant submissions to the Planetary Data System are available at <a href="//pds.nasa.gov/pds4/about/portal.shtml" target="_blank">Archiving under PDS4</a>. 
+    * Guidelines for preparing PDS4 compliant submissions to the Planetary Data System are available at <a href="//pds.nasa.gov/pds4/about/portal.shtml" target="_blank">Archiving under PDS4</a>.
 
 The "Data Status" tab provides the availability date and "PDS Certification"
 status of each of the data sets or data volumes in the Ring-Moon Systems Node holdings.
@@ -50,11 +50,11 @@ site.</a>
 The links in the following table are to the respective Ring-Moon Systems Node support
 pages (same destinations as the tabs at the top of the page).
 
-Program | Appendix | Step 1 Proposal Due | Step 2 Proposal Due  
----|---|---|---|  
-[Cassini Data Analysis and Participating Scientists Program (CDAPS)](cdaps.html) | C.10 | 6/1/2015 | 8/18/2015  
-[Planetary Data Archiving, Restoration, and Tools (PDART)](pdart.html) | C.7 | 5/15/2015 | 7/17/2015  
-[Solar System Workings (SSW)](ssw.html) | C.3 | 6/11/2015 | 9/10/2015 & 2/25/2016  
+Program | Appendix | Step 1 Proposal Due | Step 2 Proposal Due
+---|---|---|---|
+[Cassini Data Analysis and Participating Scientists Program (CDAPS)](cdaps.html) | C.10 | 6/1/2015 | 8/18/2015
+[Planetary Data Archiving, Restoration, and Tools (PDART)](pdart.html) | C.7 | 5/15/2015 | 7/17/2015
+[Solar System Workings (SSW)](ssw.html) | C.3 | 6/11/2015 | 9/10/2015 & 2/25/2016
 
 ### Additional PDS Support
 
@@ -62,8 +62,6 @@ Links to ROSES support pages at the other PDS Nodes can be found at the PDS
 Engineering Node's <a href="//pds.nasa.gov/ROSES/roses.shtml" target="_blank">ROSES support</a>
 page.
 
-The Ring-Moon Systems Node's [ ROSES 2014](/roses/2014/index.html) support page.
+The Ring-Moon Systems Node's [ ROSES 2014]({{ site.baseurl }}/roses/2014/index.html) support page.
 
-The Ring-Moon Systems Node's [ ROSES 2013](/roses/2013/index.html) support page.
-
-
+The Ring-Moon Systems Node's [ ROSES 2013]({{ site.baseurl }}/roses/2013/index.html) support page.

--- a/website/roses/2016/help.html
+++ b/website/roses/2016/help.html
@@ -50,7 +50,7 @@ tabs: roses_2016
    - Which PDS node? Links to all the PDS nodes are found underneath the bottom of this page.
      To determine if a node is the right one to archive your data, look at the node's web site
      to see the types of data already archived there. Contact information for all PDS nodes
-     is available on their web sites and on the <a href="//pds.jpl.nasa.gov/contact/contact.shtml" target="_blank">main PDS website</a> Contact page. Contact the [Ring-Moon Systems Node](/cgi-bin/comments/form.pl) here.
+     is available on their web sites and on the <a href="//pds.jpl.nasa.gov/contact/contact.shtml" target="_blank">main PDS website</a> Contact page. Contact the [Ring-Moon Systems Node]({{ site.baseurl }}/cgi-bin/comments/form.pl) here.
 
 ### Estimation of Effort.
 

--- a/website/roses/2017/help.html
+++ b/website/roses/2017/help.html
@@ -50,7 +50,7 @@ tabs: roses_2017
    - Which PDS node? Links to all the PDS nodes are found underneath the bottom of this page.
      To determine if a node is the right one to archive your data, look at the node's web site
      to see the types of data already archived there. Contact information for all PDS nodes
-     is available on their web sites and on the <a href="//pds.jpl.nasa.gov/contact/contact.shtml" target="_blank">main PDS website</a> Contact page. Contact the [Ring-Moon Systems Node](/cgi-bin/comments/form.pl) here.
+     is available on their web sites and on the <a href="//pds.jpl.nasa.gov/contact/contact.shtml" target="_blank">main PDS website</a> Contact page. Contact the [Ring-Moon Systems Node]({{ site.baseurl }}/cgi-bin/comments/form.pl) here.
 
 ### Estimation of Effort.
 
@@ -71,11 +71,11 @@ tabs: roses_2017
 
 ### Additional PDS Support
 
-The PDS has prepared a <a href="https://pds.jpl.nasa.gov/documents/Individual-Proposers-Archive-Guide-v11.pdf" target="_blank">Proposer's Archiving Guide</a>, specifically to support DAP proposers. 
+The PDS has prepared a <a href="https://pds.jpl.nasa.gov/documents/Individual-Proposers-Archive-Guide-v11.pdf" target="_blank">Proposer's Archiving Guide</a>, specifically to support DAP proposers.
 
-For more information about proposing with respect to PDS archiving, see the PDS Engineering Node's <a href="https://pds.jpl.nasa.gov/pds4/propose/proposing.shtml" target="_blank">Information for Proposers</a> page.                                                     
+For more information about proposing with respect to PDS archiving, see the PDS Engineering Node's <a href="https://pds.jpl.nasa.gov/pds4/propose/proposing.shtml" target="_blank">Information for Proposers</a> page.
 
-The PDS Engineering Node's <a href="//pds.nasa.gov/ROSES/roses.shtml" target="_blank">ROSES support</a> page includes links to ROSES support pages at the other PDS Discipline Nodes. 
+The PDS Engineering Node's <a href="//pds.nasa.gov/ROSES/roses.shtml" target="_blank">ROSES support</a> page includes links to ROSES support pages at the other PDS Discipline Nodes.
 
 ### RMS Node Support for Previous ROSES calls:
 

--- a/website/roses/2018/help.html
+++ b/website/roses/2018/help.html
@@ -11,8 +11,8 @@ tabs: roses_2018
 ### Data Management Plans (DMP)
 
   - Most of the programs relevant to the Ring-Moon Systems Node require a DMP. For details relevant to a specific program see that program's instructions.
-  
-  - Proposers requiring a DMP are strongly encouraged to use the Planetary Science Division's DMP template, which may be downloaded as a word doc, or a latex template in the form of a .txt file from the <a href="https://science.nasa.gov/templates-planetary-science-division-appendix-c-roses-proposals" target="_blank">SARA web page</a>. 
+
+  - Proposers requiring a DMP are strongly encouraged to use the Planetary Science Division's DMP template, which may be downloaded as a word doc, or a latex template in the form of a .txt file from the <a href="https://science.nasa.gov/templates-planetary-science-division-appendix-c-roses-proposals" target="_blank">SARA web page</a>.
 
 ### Use of Existing PDS Data Sets
 
@@ -56,7 +56,7 @@ tabs: roses_2018
    - Which PDS node? Links to all the PDS nodes are found underneath the bottom of this page.
      To determine if a node is the right one to archive your data, look at the node's web site
      to see the types of data already archived there. Contact information for all PDS nodes
-     is available on their web sites and on the <a href="//pds.jpl.nasa.gov/contact/contact.shtml" target="_blank">main PDS website</a> Contact page. Contact the [Ring-Moon Systems Node](/cgi-bin/comments/form.pl) here.
+     is available on their web sites and on the <a href="//pds.jpl.nasa.gov/contact/contact.shtml" target="_blank">main PDS website</a> Contact page. Contact the [Ring-Moon Systems Node]({{ site.baseurl }}/cgi-bin/comments/form.pl) here.
 
 ### Estimation of Effort.
 
@@ -77,11 +77,11 @@ tabs: roses_2018
 
 ### Additional PDS Support
 
-The PDS has prepared a <a href="https://pds.jpl.nasa.gov/documents/Individual-Proposers-Archive-Guide-v11.pdf" target="_blank">Proposer's Archiving Guide</a>, specifically to support DAP proposers. 
+The PDS has prepared a <a href="https://pds.jpl.nasa.gov/documents/Individual-Proposers-Archive-Guide-v11.pdf" target="_blank">Proposer's Archiving Guide</a>, specifically to support DAP proposers.
 
-For more information about proposing with respect to PDS archiving, see the PDS Engineering Node's <a href="https://pds.jpl.nasa.gov/pds4/propose/proposing.shtml" target="_blank">Information for Proposers</a> page.                                                     
+For more information about proposing with respect to PDS archiving, see the PDS Engineering Node's <a href="https://pds.jpl.nasa.gov/pds4/propose/proposing.shtml" target="_blank">Information for Proposers</a> page.
 
-The PDS Engineering Node's <a href="//pds.nasa.gov/ROSES/roses.shtml" target="_blank">ROSES support</a> page includes links to ROSES support pages at the other PDS Discipline Nodes. 
+The PDS Engineering Node's <a href="//pds.nasa.gov/ROSES/roses.shtml" target="_blank">ROSES support</a> page includes links to ROSES support pages at the other PDS Discipline Nodes.
 
 ### RMS Node Support for Previous ROSES calls:
 

--- a/website/roses/2019/help.html
+++ b/website/roses/2019/help.html
@@ -11,8 +11,8 @@ tabs: roses_2019
 ### Data Management Plans (DMP)
 
   - Most of the programs relevant to the Ring-Moon Systems Node require a DMP. For details relevant to a specific program see that program's instructions.
-  
-  - Proposers requiring a DMP are strongly encouraged to use the Planetary Science Division's DMP template, which may be downloaded as a word doc, or a latex template in the form of a .txt file from the <a href="https://science.nasa.gov/templates-planetary-science-division-appendix-c-roses-proposals" target="_blank">SARA web page</a>. 
+
+  - Proposers requiring a DMP are strongly encouraged to use the Planetary Science Division's DMP template, which may be downloaded as a word doc, or a latex template in the form of a .txt file from the <a href="https://science.nasa.gov/templates-planetary-science-division-appendix-c-roses-proposals" target="_blank">SARA web page</a>.
 
 ### Use of Existing PDS Data Sets
 
@@ -52,14 +52,14 @@ tabs: roses_2019
      your proposal. We can tell you what would be required to make your data into a compliant archive,
      and make sure you are connected with the right PDS node to handle your data. The node can
      provide a letter stating that it is aware of your proposed effort and can support the
-     archiving of your data. Contact the RMS Node using **[our comments system](/cgi-bin/comments/form.pl)**,
-     or by emailing a member of staff - email addresses are included in the pages linked in the "Contacts" section 
+     archiving of your data. Contact the RMS Node using **[our comments system]({{ site.baseurl }}/cgi-bin/comments/form.pl)**,
+     or by emailing a member of staff - email addresses are included in the pages linked in the "Contacts" section
      of the navigation bar to the left of this and most of our web pages.
-   - Which PDS node? Refer to the information about each of the PDS nodes available on the 
-     <a href="https://pds.nasa.gov/home/about/node-descriptions.shtml" target="_blank">main PDS website</a> node descriptions page. 
+   - Which PDS node? Refer to the information about each of the PDS nodes available on the
+     <a href="https://pds.nasa.gov/home/about/node-descriptions.shtml" target="_blank">main PDS website</a> node descriptions page.
      Or use the links to the individual PDS nodes at the bottom of this page, and look at the node's web site
-     to see the types of data already archived there. 
-     
+     to see the types of data already archived there.
+
 
 ### Estimation of Effort.
 
@@ -80,11 +80,11 @@ tabs: roses_2019
 
 ### Additional PDS Support
 
-   - For more information about proposing with respect to PDS archiving, see the PDS Engineering Node's <a href="https://pds.nasa.gov/home/proposers/ " target="_blank">Information for Proposers</a> page. 
+   - For more information about proposing with respect to PDS archiving, see the PDS Engineering Node's <a href="https://pds.nasa.gov/home/proposers/ " target="_blank">Information for Proposers</a> page.
 
-   - From that page, follow the link to the Proposers to Individual R&A Programs page which contains links to several additional 
-     resources including one to the Proposer's Archiving Guide, written specifically to support DAP proposers, and links to ROSES 
-     support pages at the individual nodes..                                                     
+   - From that page, follow the link to the Proposers to Individual R&A Programs page which contains links to several additional
+     resources including one to the Proposer's Archiving Guide, written specifically to support DAP proposers, and links to ROSES
+     support pages at the individual nodes..
 
 ### RMS Node Support for Previous ROSES calls:
 

--- a/website/roses/2020/help.html
+++ b/website/roses/2020/help.html
@@ -11,12 +11,12 @@ tabs: roses_2020
 ### Letter of Support
 
   - Most of the programs relevant to the Ring-Moon Systems Node require a letter of support from the intended curating node. <b>Proposers are strongly encouraged to contact the node well in advance (at least two weeks) of the proposal due date.</b> There are several steps the node must complete, including determining if archiving your data with this node is appropriate, prior to generating a letter of support. You will not be the only PI seeking a letter.
-  
+
 ### Data Management Plans (DMP)
 
   - Most of the programs relevant to the Ring-Moon Systems Node require a DMP. For details relevant to a specific program see that program's instructions.
-  
-  - Proposers requiring a DMP are strongly encouraged to use the Planetary Science Division's DMP template, which may be downloaded as a word doc, or a latex template in the form of a .txt file from the <a href="https://science.nasa.gov/templates-planetary-science-division-appendix-c-roses-proposals" target="_blank">SARA web page</a>. 
+
+  - Proposers requiring a DMP are strongly encouraged to use the Planetary Science Division's DMP template, which may be downloaded as a word doc, or a latex template in the form of a .txt file from the <a href="https://science.nasa.gov/templates-planetary-science-division-appendix-c-roses-proposals" target="_blank">SARA web page</a>.
 
 ### Use of Existing PDS Data Sets
 
@@ -56,14 +56,14 @@ tabs: roses_2020
      your proposal. We can tell you what would be required to make your data into a compliant archive,
      and make sure you are connected with the right PDS node to handle your data. The node can
      provide a letter stating that it is aware of your proposed effort and can support the
-     archiving of your data. Contact the RMS Node using **[our comments system](/cgi-bin/comments/form.pl)**,
-     or by emailing a member of staff - email addresses are included in the pages linked in the "Contacts" section 
+     archiving of your data. Contact the RMS Node using **[our comments system]({{ site.baseurl }}/cgi-bin/comments/form.pl)**,
+     or by emailing a member of staff - email addresses are included in the pages linked in the "Contacts" section
      of the navigation bar to the left of this and most of our web pages.
-   - Which PDS node? Refer to the information about each of the PDS nodes available on the 
-     <a href="https://pds.nasa.gov/home/about/node-descriptions.shtml" target="_blank">main PDS website</a> node descriptions page. 
+   - Which PDS node? Refer to the information about each of the PDS nodes available on the
+     <a href="https://pds.nasa.gov/home/about/node-descriptions.shtml" target="_blank">main PDS website</a> node descriptions page.
      Or use the links to the individual PDS nodes at the bottom of this page, and look at the node's web site
-     to see the types of data already archived there. 
-     
+     to see the types of data already archived there.
+
 
 ### Estimation of Effort.
 
@@ -84,11 +84,11 @@ tabs: roses_2020
 
 ### Additional PDS Support
 
-   - For more information about proposing with respect to PDS archiving, see the PDS Engineering Node's <a href="https://pds.nasa.gov/home/proposers/ " target="_blank">Information for Proposers</a> page. 
+   - For more information about proposing with respect to PDS archiving, see the PDS Engineering Node's <a href="https://pds.nasa.gov/home/proposers/ " target="_blank">Information for Proposers</a> page.
 
-   - From that page, follow the link to the Proposers to Individual R&A Programs page which contains links to several additional 
-     resources including one to the Proposer's Archiving Guide, written specifically to support DAP proposers, and links to ROSES 
-     support pages at the individual nodes..                                                     
+   - From that page, follow the link to the Proposers to Individual R&A Programs page which contains links to several additional
+     resources including one to the Proposer's Archiving Guide, written specifically to support DAP proposers, and links to ROSES
+     support pages at the individual nodes..
 
 ### RMS Node Support for Previous ROSES calls:
 
@@ -101,4 +101,3 @@ The Ring-Moon Systems Node's [ ROSES 2017](2017/index.html) support page.
 The Ring-Moon Systems Node's [ ROSES 2016](2016/index.html) support page.
 
 The Ring-Moon Systems Node's [ ROSES 2015](2015/index.html) support page.
-

--- a/website/rpx/campaign.html
+++ b/website/rpx/campaign.html
@@ -14,9 +14,9 @@ satellites. The edge-on viewing geometry also permited direct observations of
 the main rings' thickness, and the timing of satellite eclipses and mutual
 events that can be used to improve ephemerides.
 
-**Note:** This page contains planning tools and information used primarily in preparation for the events in 1995 and 1996. More up-to-date [observing tools](/tools/index.html) are now available elsewhere.
+**Note:** This page contains planning tools and information used primarily in preparation for the events in 1995 and 1996. More up-to-date [observing tools]({{ site.baseurl }}/tools/index.html) are now available elsewhere.
 
-* The Saturnicentric latitude of Earth and Sun during the crossing period.  
+* The Saturnicentric latitude of Earth and Sun during the crossing period.
 [ ![- ]({{ site.assets_url }}rpx/diagram_t.gif "Click to get the full size diagram")](diagram.html)
 
 * [ A "Dear Colleague" letter](overview.html) distributed prior to the 1993 DPS Meeting.
@@ -26,7 +26,7 @@ events that can be used to improve ephemerides.
 
 ## Ephemerides
 
-The 1995-6 ephemeris distribution service has been disabled. 
+The 1995-6 ephemeris distribution service has been disabled.
 Contact the [PDS Navigation and Ancillary Information Facility Node](//naif.jpl.nasa.gov/naif/){:target="_blank"}
 for data and software.
 
@@ -47,13 +47,13 @@ Prometheus event times changed rather significantly.
 This utility enables you to render a diagram
 showing the appearance of Saturn, its moons and rings at any time during 1995
 and 1996. Diagrams are rendered in Postscript format. Here are a few
-[examples](viewer/examples/). Newer [observing tools](/tools/index.html) are now recommended.
+[examples](viewer/examples/). Newer [observing tools]({{ site.baseurl }}/tools/index.html) are now recommended.
 
 ## [Saturn Moon Tracker]({{ site.assets_url }}tools/tracker2_sat.html)
 
 This utility enables you to generate diagrams
 showing the motion of Saturn's moons during 1995 and 1996. Diagrams are
-rendered in Postscript format. Newer [observing tools](/tools/index.html) are
+rendered in Postscript format. Newer [observing tools]({{ site.baseurl }}/tools/index.html) are
 now recommended.
 
 ## [Tucson Workshop](tucson_1994)

--- a/website/rpx/index.html
+++ b/website/rpx/index.html
@@ -22,12 +22,12 @@ which also provides links to the data.
 
   * **Note: Only those volumes showing a status of "Archived" have fully completed the PDS peer review process.**
 
-  * Clicking on the VOLUME_ID will allow you to browse the volume. 
+  * Clicking on the VOLUME_ID will allow you to browse the volume.
 
-  * To download an entire volume, right click on that volume's "Bundled" link. 
+  * To download an entire volume, right click on that volume's "Bundled" link.
 
 The bundled volumes are provided in .tar.gz format. For information on opening
-files of this type, click [here](/help/targz.html).
+files of this type, click [here]({{ site.baseurl }}/help/targz.html).
 
 
 {% assign table_name = "Saturn RPX Data Releases" %}
@@ -42,8 +42,8 @@ us.
 
 ## More information on the 1995-6 Observing Campaign
 
-  * [On-line facilities](campaign.html) from the 1995-6 observing campaign are still available but no longer supported. Included are diagrams, planning tools, ephemerides and workshop proceedings. 
+  * [On-line facilities](campaign.html) from the 1995-6 observing campaign are still available but no longer supported. Included are diagrams, planning tools, ephemerides and workshop proceedings.
 
-  * [Proceedings](tucson_1994/proceedings) from the [1994 planning workshop](tucson_1994) in Tucson. 
+  * [Proceedings](tucson_1994/proceedings) from the [1994 planning workshop](tucson_1994) in Tucson.
 
-  * [Announcement and Program](wellesley_1997) for the 1997 Wellesley Workshop. 
+  * [Announcement and Program](wellesley_1997) for the 1997 Wellesley Workshop.

--- a/website/rpx/viewer/examples/dione.html
+++ b/website/rpx/viewer/examples/dione.html
@@ -6,27 +6,27 @@ title: "Saturn Viewer Example: Dione/Rhea Mutual Event"
 
 # Saturn Viewer Example: Dione/Rhea Mutual Event
 
-As listed in [Table 5](/rpx/tucson_1994/rpx_bdl/table5.dat)
-of [Arlot and Thuillot (_Icarus_ **105**, 427-440, 1993)](//doi.org/10.1006/icar.1993.1139){:target="_blank"}, 
-Dione will partially occult Rhea on 20 May 1995.  
+As listed in [Table 5]({{ site.baseurl }}/rpx/tucson_1994/rpx_bdl/table5.dat)
+of [Arlot and Thuillot (_Icarus_ **105**, 427-440, 1993)](//doi.org/10.1006/icar.1993.1139){:target="_blank"},
+Dione will partially occult Rhea on 20 May 1995.
 
-![Dione/Rhea Event]({{ site.assets_url }}rpx/viewer/examples/dione.gif)  
+![Dione/Rhea Event]({{ site.assets_url }}rpx/viewer/examples/dione.gif)
 
-    
-    
+
+
     Input Parameters
     ----------------
-    
+
      Observation time (UTC): 1995-5-20 9:40:20
     Field of view (seconds): .4
                Central body: Dione (604)
      Maximum star magnitude: 0.
           Minimum disk size: 0.
                 Annotations: Off
-    
+
     Field of View Description (J2000)
     ---------------------------------
-    
+
          Body          RA                  Dec                 dRA (")    dDec (")
      699 Saturn        23h 37m 31.0944s    -4d 32m 17.477s       0.000      0.000
      601 Mimas         23h 37m 29.4856s    -4d 32m 14.960s     -24.057      2.517
@@ -45,6 +45,6 @@ Dione will partially occult Rhea on 20 May 1995.
      615 Atlas         23h 37m 32.2883s    -4d 32m 18.940s      17.851     -1.462
      616 Prometheus    23h 37m 32.1314s    -4d 32m 18.752s      15.506     -1.275
      617 Pandora       23h 37m 30.5602s    -4d 32m 16.810s      -7.988      0.667
-    
+
       Subsolar latitude (deg):   2.67976  to   2.73505
      Ring opening angle (deg):   0.05473  (lit)

--- a/website/rpx/viewer/examples/rhea.html
+++ b/website/rpx/viewer/examples/rhea.html
@@ -6,28 +6,28 @@ title: "Saturn Viewer Example: Rhea Eclipse"
 
 # Saturn Viewer Example: Rhea Eclipse
 
-As listed in [Table 4](/rpx/tucson_1994/rpx_bdl/table4.dat)
-of [Arlot and Thuillot (_Icarus_ **105**, 427-440, 1993)](//doi.org/10.1006/icar.1993.1139){:target="_blank"}, 
+As listed in [Table 4]({{ site.baseurl }}/rpx/tucson_1994/rpx_bdl/table4.dat)
+of [Arlot and Thuillot (_Icarus_ **105**, 427-440, 1993)](//doi.org/10.1006/icar.1993.1139){:target="_blank"},
 Rhea will disappear into Saturn's shadow at 0:47 UTC on 20 May 1995. Note that Rhea will be
-partially obscured by the rings at this time.  
+partially obscured by the rings at this time.
 
-![Rhea Eclipse]({{ site.assets_url }}rpx/viewer/examples/rhea.gif)  
+![Rhea Eclipse]({{ site.assets_url }}rpx/viewer/examples/rhea.gif)
 
-    
-    
+
+
     Input Parameters
     ----------------
-    
+
      Observation time (UTC): 1995-5-20 0:47
     Field of view (seconds): .4
                Central body: Rhea (605)
      Maximum star magnitude: 0.
           Minimum disk size: 0.
                 Annotations: Off
-    
+
     Field of View Description (J2000)
     ---------------------------------
-    
+
          Body          RA                  Dec                 dRA (")    dDec (")
      699 Saturn        23h 37m 25.0297s    -4d 32m 51.252s       0.000      0.000
      601 Mimas         23h 37m 26.6103s    -4d 32m 53.873s      23.634     -2.620
@@ -46,7 +46,6 @@ partially obscured by the rings at this time.
      615 Atlas         23h 37m 23.8620s    -4d 32m 49.833s     -17.461      1.420
      616 Prometheus    23h 37m 23.7497s    -4d 32m 49.689s     -19.139      1.564
      617 Pandora       23h 37m 26.1245s    -4d 32m 52.600s      16.370     -1.348
-    
+
       Subsolar latitude (deg):   2.68519  to   2.74048
      Ring opening angle (deg):   0.06613  (lit)
-    

--- a/website/saturn/index.html
+++ b/website/saturn/index.html
@@ -13,12 +13,12 @@ title: "PIA00335: The Saturn System"
   * Search for Saturn system data in [OPUS]({{ site.opus_url }}/planet=Saturn&widgets=planet,target){:target="_blank"}
   * Table of [ring information](saturn_rings_table.html)
   * Table of [satellite information](saturn_satellites_table.html)
-  * Outer planet [ephemeris tools](/tools/)
-  * Information about [Cassini](/cassini/) observations
-  * Information about [Voyager](/voyager/) observations
-  * Information about [HST](/hst/) observations
-  * [Ring occultation data](/ringocc/)
-  * [Saturn Ring Plane Crossings of 1995](/rpx/)
+  * Outer planet [ephemeris tools]({{ site.baseurl }}/tools/)
+  * Information about [Cassini]({{ site.baseurl }}/cassini/) observations
+  * Information about [Voyager]({{ site.baseurl }}/voyager/) observations
+  * Information about [HST]({{ site.baseurl }}/hst/) observations
+  * [Ring occultation data]({{ site.baseurl }}/ringocc/)
+  * [Saturn Ring Plane Crossings of 1995]({{ site.baseurl }}/rpx/)
 
 ## Press Release Image Galleries
 

--- a/website/saturn/index.html
+++ b/website/saturn/index.html
@@ -6,7 +6,7 @@ title: "PIA00335: The Saturn System"
 
 # The Saturn System
 
-[ ![\[PIA00335\]]({{ site.assets_url }}/saturn/PIA00335_thumb.jpg) ]({{ site.assets_url }}press_releases/pages/PIA00xxx/PIA00335.html)
+[ ![\[PIA00335\]]({{ site.assets_url }}saturn/PIA00335_thumb.jpg) ]({{ site.assets_url }}press_releases/pages/PIA00xxx/PIA00335.html)
 
 ## Links to Ring-Moon Systems Node Resources
 

--- a/website/tools/index.html
+++ b/website/tools/index.html
@@ -22,7 +22,7 @@ the [Juno mission](#juno).
 
 <div class = "row">
 <div class = "col-xl-2 col-lg-2 col-md-3 col-sm-3 col-xs-3">
-    <img src="{{  site.assets_url }}tools/viewer_thumb.gif" alt="Planet Viewers" aria-hidden="true">
+    <img src="{{ site.assets_url }}tools/viewer_thumb.gif" alt="Planet Viewers" aria-hidden="true">
 </div>
 <div class = "col-xl-10 col-lg-10 col-md-9 col-sm-9 col-xs-9" markdown="1">
 
@@ -43,7 +43,7 @@ Click for [Jupiter](viewer3_jup.shtml), [Saturn](viewer3_sat.shtml),
 
 <div class = "row">
 <div class = "col-xl-2 col-lg-2 col-md-3 col-sm-3 col-xs-3">
-    <img src="{{  site.assets_url }}tools/tracker_thumb.gif" alt="Moon Trackers" aria-hidden="true">
+    <img src="{{ site.assets_url }}tools/tracker_thumb.gif" alt="Moon Trackers" aria-hidden="true">
 </div>
 <div class = "col-xl-10 col-lg-10 col-md-9 col-sm-9 col-xs-9" markdown="1">
 
@@ -66,7 +66,7 @@ Click for [Jupiter](tracker3_jup.shtml), [Saturn](tracker3_sat.shtml),
 
 <div class = "row">
 <div class = "col-xl-2 col-lg-2 col-md-3 col-sm-3 col-xs-3">
-    <img src="{{  site.assets_url }}/tools/ephem_thumb.gif" alt="Ephemeris Generators" aria-hidden="true">
+    <img src="{{ site.assets_url }}tools/ephem_thumb.gif" alt="Ephemeris Generators" aria-hidden="true">
 </div>
 <div class = "col-xl-10 col-lg-10 col-md-9 col-sm-9 col-xs-9" markdown="1">
 

--- a/website/tools/index.html
+++ b/website/tools/index.html
@@ -79,9 +79,9 @@ time. You are free to specify which of a variety of useful quantities to
 tabulate (e.g. RA and dec, phase angle, ring opening angle, distance, lunar
 phase, etc.).
 
-Click for [Jupiter](/tools/ephem3_jup.shtml), [Saturn](/tools/ephem3_sat.shtml),
-[Uranus](/tools/ephem3_ura.shtml), [Neptune](/tools/ephem3_nep.shtml),
-[Pluto](/tools/ephem3_plu.shtml), or [Mars](/tools/ephem3_mar.shtml).
+Click for [Jupiter]({{ site.baseurl }}/tools/ephem3_jup.shtml), [Saturn]({{ site.baseurl }}/tools/ephem3_sat.shtml),
+[Uranus]({{ site.baseurl }}/tools/ephem3_ura.shtml), [Neptune]({{ site.baseurl }}/tools/ephem3_nep.shtml),
+[Pluto]({{ site.baseurl }}/tools/ephem3_plu.shtml), or [Mars]({{ site.baseurl }}/tools/ephem3_mar.shtml).
 
 
 </div>
@@ -90,7 +90,7 @@ Click for [Jupiter](/tools/ephem3_jup.shtml), [Saturn](/tools/ephem3_sat.shtml),
 </div><!-- /container -->
 
 
-{: #juno } 
+{: #juno }
 ## Juno Tools
 
   * [Jupiter Viewer](viewer3_jupj.shtml)
@@ -112,25 +112,25 @@ Click for [Jupiter](/tools/ephem3_jup.shtml), [Saturn](/tools/ephem3_sat.shtml),
 {: #cassini}
 ## Cassini Tools
 
-  * [Saturn Viewer](/tools/viewer3_satc.shtml)
-  * [Saturn Moon Tracker](/tools/tracker3_satc.shtml)
-  * [Saturn Ephemeris Generator](/tools/ephem3_satc.shtml)
-  * [Jupiter Viewer](/tools/viewer3_jupc.shtml)
-  * [Jupiter Moon Tracker](/tools/tracker3_jupc.shtml)
-  * [Jupiter Ephemeris Generator](/tools/ephem3_jupc.shtml)
+  * [Saturn Viewer]({{ site.baseurl }}/tools/viewer3_satc.shtml)
+  * [Saturn Moon Tracker]({{ site.baseurl }}/tools/tracker3_satc.shtml)
+  * [Saturn Ephemeris Generator]({{ site.baseurl }}/tools/ephem3_satc.shtml)
+  * [Jupiter Viewer]({{ site.baseurl }}/tools/viewer3_jupc.shtml)
+  * [Jupiter Moon Tracker]({{ site.baseurl }}/tools/tracker3_jupc.shtml)
+  * [Jupiter Ephemeris Generator]({{ site.baseurl }}/tools/ephem3_jupc.shtml)
 
 
 {: #clipper}
 ## Europa Clipper Tools
 
-  * [Jupiter Viewer](/tools/viewer3_jupec.shtml)
-  * [Jupiter Moon Tracker](/tools/tracker3_jupec.shtml)
-  * [Jupiter Ephemeris Generator](/tools/ephem3_jupec.shtml)
+  * [Jupiter Viewer]({{ site.baseurl }}/tools/viewer3_jupec.shtml)
+  * [Jupiter Moon Tracker]({{ site.baseurl }}/tools/tracker3_jupec.shtml)
+  * [Jupiter Ephemeris Generator]({{ site.baseurl }}/tools/ephem3_jupec.shtml)
 
 
 {: #juice}
 ## JUICE Tools
 
-  * [Jupiter Viewer](/tools/viewer3_jupjc.shtml)
-  * [Jupiter Moon Tracker](/tools/tracker3_jupjc.shtml)
-  * [Jupiter Ephemeris Generator](/tools/ephem3_jupjc.shtml)
+  * [Jupiter Viewer]({{ site.baseurl }}/tools/viewer3_jupjc.shtml)
+  * [Jupiter Moon Tracker]({{ site.baseurl }}/tools/tracker3_jupjc.shtml)
+  * [Jupiter Ephemeris Generator]({{ site.baseurl }}/tools/ephem3_jupjc.shtml)

--- a/website/uranus/index.html
+++ b/website/uranus/index.html
@@ -16,14 +16,14 @@ Center), J. Lissauer (NASA Ames Research Center)
   * Search for Uranus system data in [OPUS]({{ site.opus_url }}/planet=Uranus&widgets=planet,target){:target="_blank"}
   * Table of [ring information](uranus_rings_table.html)
   * Table of [satellite information](uranus_satellites_table.html)
-  * Outer planet [ephemeris tools](/tools/)
-  * Information about [Voyager](/voyager/) observations
-  * Information about [HST](/hst/) observations
+  * Outer planet [ephemeris tools]({{ site.baseurl }}/tools/)
+  * Information about [Voyager]({{ site.baseurl }}/voyager/) observations
+  * Information about [HST]({{ site.baseurl }}/hst/) observations
 
 ## Press Release Image Galleries
 
-  * Images from [Voyager](/galleries/voyager_uranus.html)
-  * All NASA press releases about the [Uranus system](/galleries/target_uranus.html)
+  * Images from [Voyager]({{ site.baseurl }}/galleries/voyager_uranus.html)
+  * All NASA press releases about the [Uranus system]({{ site.baseurl }}/galleries/target_uranus.html)
   * [Interactive story](viewspace/) of the 2007-2008 ring plane crossings with images and movies
 
 ## Related Web Sites

--- a/website/urpx/index.html
+++ b/website/urpx/index.html
@@ -15,12 +15,12 @@ mutual events that can be used to improve ephemerides.
 
 ## Data Sets
 
-  * HST data of the URPX event can be identified via [this OPUS search](//opus.pds-rings.seti.org/#/instrument=Hubble+WFPC2,Hubble+WFC3,Hubble+STIS,Hubble+ACS,Hubble+NICMOS&target=Uranus,Mab&time1=2007-04-01T00:00:00.000&time2=2008-04-01T00:00){:target="_blank"}. 
+  * HST data of the URPX event can be identified via [this OPUS search](//opus.pds-rings.seti.org/#/instrument=Hubble+WFPC2,Hubble+WFC3,Hubble+STIS,Hubble+ACS,Hubble+NICMOS&target=Uranus,Mab&time1=2007-04-01T00:00:00.000&time2=2008-04-01T00:00){:target="_blank"}.
 
-  * The PDS Ring-Moon Systems Node would be glad to archive additional data of the URPX event.  
+  * The PDS Ring-Moon Systems Node would be glad to archive additional data of the URPX event.
     Observers interested in archiving data should contact us at [pds-rings@seti.org](mailto:pds-rings@seti.org)
 
 ## Tools
 
-  * The [Ring-Moon Systems Node On-Line Tools](/tools/) are available for visualizing the changing geometry 
+  * The [Ring-Moon Systems Node On-Line Tools]({{ site.baseurl }}/tools/) are available for visualizing the changing geometry
     and assisting with observation planning.

--- a/website/voyager/ck/index.html
+++ b/website/voyager/ck/index.html
@@ -25,14 +25,14 @@ tapes contained the direction in space that the instrument was pointed. Today,
 many of the SEDR tapes have been lost.
 
 The one major exception is Voyager's Imaging Science Subsystem
-([ISS](/voyager/iss/index.html)), for which the SEDR files were later converted to
+([ISS]({{ site.baseurl }}/voyager/iss/index.html)), for which the SEDR files were later converted to
 Vax binary format and are still widely available. However, the ISS SEDR files
 only describe the camera direction and orientation at the time when images
 were taken, leaving large intervals during each flyby when the pointing is
 unknown.
 
 The Ring-Moon Systems Node has recently obtained SEDR files for the Ultraviolet
-Spectrometer ([UVS](/voyager/uvs/index.html)), which have the advantage that they
+Spectrometer ([UVS]({{ site.baseurl }}/voyager/uvs/index.html)), which have the advantage that they
 provide nearly complete temporal coverage of each encounter. However, the
 accuracy is not as good as that of the ISS SEDR files.
 
@@ -44,9 +44,9 @@ would like any of these files.
 
 Unfortunately, because the Voyager mission pre-dates the PDS and the SPICE
 toolkit, reliable C kernels were never generated for the scan platform, which
-carried the four remote sensing instruments: [ISS](/voyager/iss/index.html),
-[IRIS](/voyager/iris/index.html), [PPS](/voyager/pps/index.html), and
-[UVS](/voyager/uvs/index.html). The Ring-Moon Systems Node has recently undertaken the project
+carried the four remote sensing instruments: [ISS]({{ site.baseurl }}/voyager/iss/index.html),
+[IRIS]({{ site.baseurl }}/voyager/iris/index.html), [PPS]({{ site.baseurl }}/voyager/pps/index.html), and
+[UVS]({{ site.baseurl }}/voyager/uvs/index.html). The Ring-Moon Systems Node has recently undertaken the project
 of generating reliable C kernels for all of the Voyager flybys.
 
 To date, we have generated C kernels for the Voyager 1 flyby of Saturn. Other

--- a/website/voyager/crs/index.html
+++ b/website/voyager/crs/index.html
@@ -22,18 +22,18 @@ They simply pass completely through the CRS. However, in passing through, the
 particles leave signs that they were there.
 
 Visit the official Voyager [Cosmic Ray
-Experiment](/voyager.jpl.nasa.gov/mission/spacecraft/instruments/crs/){:target="_blank"} home page.
+Experiment](//voyager.jpl.nasa.gov/mission/spacecraft/instruments/crs/){:target="_blank"} home page.
 
 ## Science Objectives
 
-  * To measure the energy spectrum of electrons from 3 - 110 MeV. 
+  * To measure the energy spectrum of electrons from 3 - 110 MeV.
 
-  * To measure the energy spectra and elemental composition of all cosmic ray nuclei from hydrogen through iron over an energy range from approximately 1 - 500MeV/nuc. 
+  * To measure the energy spectra and elemental composition of all cosmic ray nuclei from hydrogen through iron over an energy range from approximately 1 - 500MeV/nuc.
 
-  * To provide information on the energy content, origin, acceleration process, life history, and dynamics of cosmic rays in the galaxy, and contribute to an understanding of the nucleosynthesis of elements in cosmic ray sources. 
+  * To provide information on the energy content, origin, acceleration process, life history, and dynamics of cosmic rays in the galaxy, and contribute to an understanding of the nucleosynthesis of elements in cosmic ray sources.
 
-  * To provide information on the transport of cosmic rays, Jovian electrons, and low energy interplanetary particles over an extended region of interplanetary space. 
+  * To provide information on the transport of cosmic rays, Jovian electrons, and low energy interplanetary particles over an extended region of interplanetary space.
 
-  * To measure the three-dimentional streaming patterns of nuclei from Hydrogen through Iron and electrons over an extended range. 
+  * To measure the three-dimentional streaming patterns of nuclei from Hydrogen through Iron and electrons over an extended range.
 
-  * To measure particle charge compostion in the magnetosphere of Jupiter, Saturn, Uranus, and Neptune. 
+  * To measure particle charge compostion in the magnetosphere of Jupiter, Saturn, Uranus, and Neptune.

--- a/website/voyager/iris/expanded_volumes.html
+++ b/website/voyager/iris/expanded_volumes.html
@@ -18,27 +18,26 @@ binary and ASCII formats compatible with all modern computer systems.
 Comments are welcome. Note, the Uranus and Neptune data sets were obtained in
 a different format, and expanded archives are not currently planned.
 
-  * Clicking on the VOLUME_ID will allow you to browse the volume. 
+  * Clicking on the VOLUME_ID will allow you to browse the volume.
 
-  * To download an entire volume, right click on that volume's "Bundled" link in the second column. 
+  * To download an entire volume, right click on that volume's "Bundled" link in the second column.
 
 The bundled volumes are provided in .tar.gz format. For information on opening
-files of this type, click [here](/help/targz.html).
+files of this type, click [here]({{ site.baseurl }}/help/targz.html).
 
-  * Jupiter data: [VGIRIS_0001 (peer review)]({{ site.viewmaster_url }}volumes/VGIRIS_xxxx_peer_review/VGIRIS_0001/){:target="_blank"} ([bundle]({{ site.holdings_url }}archives-volumes/VGIRIS_xxxx_peer_review/VGIRIS_0001.tar.gz)) 
-  
+  * Jupiter data: [VGIRIS_0001 (peer review)]({{ site.viewmaster_url }}volumes/VGIRIS_xxxx_peer_review/VGIRIS_0001/){:target="_blank"} ([bundle]({{ site.holdings_url }}archives-volumes/VGIRIS_xxxx_peer_review/VGIRIS_0001.tar.gz))
 
-  * Saturn data: [VGIRIS_0002 (peer review)]({{ site.viewmaster_url }}volumes/VGIRIS_xxxx_peer_review/VGIRIS_0002/){:target="_blank"} ([bundle]({{ site.holdings_url }}archives-volumes/VGIRIS_xxxx_peer_review/VGIRIS_0002.tar.gz)) 
+
+  * Saturn data: [VGIRIS_0002 (peer review)]({{ site.viewmaster_url }}volumes/VGIRIS_xxxx_peer_review/VGIRIS_0002/){:target="_blank"} ([bundle]({{ site.holdings_url }}archives-volumes/VGIRIS_xxxx_peer_review/VGIRIS_0002.tar.gz))
 
 Note that the Uranus and Neptune data sets were obtained in a different
 format, and expanded archives are not currently planned.
 
 For more information about these volumes, consult the following documentation:
 
-  * [AAREADME.TXT]({{ site.holdings_url }}volumes/VGIRIS_xxxx_peer_review/VGIRIS_0001/AAREADME.TXT){:target="_blank"}: Overview of the data set. 
-  
+  * [AAREADME.TXT]({{ site.holdings_url }}volumes/VGIRIS_xxxx_peer_review/VGIRIS_0001/AAREADME.TXT){:target="_blank"}: Overview of the data set.
 
-  * [CATALOG/DATASET.CAT]({{ site.holdings_url }}volumes/VGIRIS_xxxx_peer_review/VGIRIS_0001/CATALOG/DATASET.CAT){:target="_blank"}: Data set description. 
 
-**Note:** This version of the data supercedes the first preliminary draft, entitled VG_2002. That volume contains known errors and is no longer available. 
+  * [CATALOG/DATASET.CAT]({{ site.holdings_url }}volumes/VGIRIS_xxxx_peer_review/VGIRIS_0001/CATALOG/DATASET.CAT){:target="_blank"}: Data set description.
 
+**Note:** This version of the data supercedes the first preliminary draft, entitled VG_2002. That volume contains known errors and is no longer available.

--- a/website/voyager/iris/original_volume.html
+++ b/website/voyager/iris/original_volume.html
@@ -28,7 +28,7 @@ information, per row.
 Each data directory also contains a PDS format file
 **IRISHEDR.FMT** describing the format of each row.
 
-Each data directory contains a **CALIB** subdirectory, containing calibration information 
+Each data directory contains a **CALIB** subdirectory, containing calibration information
 pre- and post-encounter, plus the noise-equivalent spectral response or "NESR".
 
 The original volume contains thermal spectra from
@@ -42,7 +42,7 @@ The original volume contains thermal spectra from
   * To download the entire original volume as a single "Bundled" file, click [here]({{ site.holdings_url }}archives-volumes/VG_20xx/VG_2001.tar.gz).
 
 The bundled volume is in .tar.gz format. For information on opening files of
-this type, click [here](/help/targz.html).
+this type, click [here]({{ site.baseurl }}/help/targz.html).
 
 ##  [Overview](original_aareadme.html)
 

--- a/website/voyager/iss/calib_images.html
+++ b/website/voyager/iss/calib_images.html
@@ -63,7 +63,7 @@ our versatile search engine to find and retrieve specific Voyager ISS data produ
 
     * To download an entire volume, right click on that volume's "Compressed Volume" link in the second column.
 The compressed volumes are provided in tar.gz format. For information on
-opening files of this type, click [here](/help/targz.html).
+opening files of this type, click [here]({{ site.baseurl }}/help/targz.html).
 
     * Browse links go to directories of browse images at various sizes with additional links to the specific image at each processing stage and the associated label file for that image.
 

--- a/website/voyager/iss/derived.html
+++ b/website/voyager/iss/derived.html
@@ -11,17 +11,17 @@ volume: volumes/VG_28xx/VG_2810/
 ## Jupiter Ring Images
 
 We provide direct access to all of the Jovian ring images as part of our
-support for [Galileo](/galileo/index.html) image analysis.
+support for [Galileo]({{ site.baseurl }}/galileo/index.html) image analysis.
 
 The following links provide thumbnails and viewing geometry information for
 the indicated subsets of the Voyager Jovian Ring images.
 
-  * [ Voyager 1 ](/galileo/vgr1_data.html)(1 image) 
-  * [ Voyager 2 inbound ](/galileo/vgr2_lophase_data.html)(12 images) 
-  * [ Voyager 2 outbound ](/galileo/vgr2_hiphase_data.html) (12 images). 
+  * [ Voyager 1 ]({{ site.baseurl }}/galileo/vgr1_data.html)(1 image)
+  * [ Voyager 2 inbound ]({{ site.baseurl }}/galileo/vgr2_lophase_data.html)(12 images)
+  * [ Voyager 2 outbound ]({{ site.baseurl }}/galileo/vgr2_hiphase_data.html) (12 images).
 
 All of these images are summarized in this [ viewing geometry
-table](/galileo/vgr_table.html).
+table]({{ site.baseurl }}/galileo/vgr_table.html).
 
 
 ## Derived Saturn Ring Profiles
@@ -34,7 +34,7 @@ We generally recommend using the data files sampled at 2-km resolution:
 
   * Dark side mosaic: [ IS1_P0001_V01_KM002.TAB]({{ url }}DATA/IS1_P0001_V01_KM002.TAB){:target="_blank"} and [.LBL]({{ url }}DATA/IS1_P0001_V01_KM002.LBL){:target="_blank"}
   * Lit side mosaic: [ IS2_P0001_V01_KM002.TAB]({{ url }}DATA/IS2_P0001_V01_KM002.TAB){:target="_blank"} and [.LBL]({{ url }}DATA/IS2_P0001_V01_KM002.LBL){:target="_blank"}
-  * Other resolutions are available in the same directory, [DATA]({{ site.viewmaster_url }}{{ page.volume }}DATA/){:target="_blank"}. 
+  * Other resolutions are available in the same directory, [DATA]({{ site.viewmaster_url }}{{ page.volume }}DATA/){:target="_blank"}.
 
 You can also download the entire volume as a tar.gz file
 [here]({{ site.holdings_url }}VG_28xx/VG_2810.tar.gz).

--- a/website/voyager/iss/index.html
+++ b/website/voyager/iss/index.html
@@ -70,7 +70,7 @@ is as follows:
 ## Image Galleries
 
 The Ring-Moon Systems Node maintains a collection of the most popular press release
-images. Visit [Jupiter]({{ site.assets_url }}galleries/voyager_jupiter.html), [Saturn]({{ site.assets_url }}/galleries/voyager_saturn.html),
+images. Visit [Jupiter]({{ site.assets_url }}galleries/voyager_jupiter.html), [Saturn]({{ site.assets_url }}galleries/voyager_saturn.html),
 [Uranus]({{ site.assets_url }}galleries/voyager_uranus.html) or [Neptune]({{ site.assets_url }}galleries/voyager_neptune.html).
 
 You can also find press release images at the [Planetary

--- a/website/voyager/iss/raw_images.html
+++ b/website/voyager/iss/raw_images.html
@@ -55,7 +55,7 @@ our versatile search engine to find and retrieve specific Voyager ISS data produ
     * To download an entire volume, right click on that volume's "Compressed Volume" link in the second column.
 
 The compressed volumes are provided in .tar.gz format. For information on
-opening files of this type, click [here](/help/targz.html).
+opening files of this type, click [here]({{ site.baseurl }}/help/targz.html).
 
 * Clicking on the corresponding "Browse" link will take you to the browse directory for the specified volume. Most volumes contain their own browse images. The exceptions are:
   * Browse images for VG_0001 & VG_0002 are on VG_0003.

--- a/website/voyager/neptune/references.html
+++ b/website/voyager/neptune/references.html
@@ -11,17 +11,16 @@ breadcrumb: voyager
 30-day reports from the Voyager 2 instrument teams. (Excerpts from _Science_,
 December 15, 1989.)
 
-  * [ Encounter overview]({{ site.assets_url }}/voyager/reference/science_v2n/overview/overview.html){:target="_blank"}
-  * [ Imaging (ISS) team report]({{ site.assets_url }}/voyager/reference/science_v2n/iss/iss.html){:target="_blank"}
-  * [ Photopolarimeter (PPS) team report]({{ site.assets_url }}/voyager/reference/science_v2n/pps/pps.html){:target="_blank"}
-  * [ Ultraviolet Spectrometer (UVS) team report]({{ site.assets_url }}/voyager/reference/science_v2n/uvs/uvs.html){:target="_blank"}
-  * [ Magnetic Fields (MAG) team report]({{ site.assets_url }}/voyager/reference/science_v2n/mag/mag.html){:target="_blank"}
-  * [ Cosmic Ray (CRS) team report]({{ site.assets_url }}/voyager/reference/science_v2n/crs/crs.html){:target="_blank"}
-  * [ Plasma Wave (PWS) team report]({{ site.assets_url }}/voyager/reference/science_v2n/pws/pws.html){:target="_blank"}
+  * [ Encounter overview]({{ site.assets_url }}voyager/reference/science_v2n/overview/overview.html){:target="_blank"}
+  * [ Imaging (ISS) team report]({{ site.assets_url }}voyager/reference/science_v2n/iss/iss.html){:target="_blank"}
+  * [ Photopolarimeter (PPS) team report]({{ site.assets_url }}voyager/reference/science_v2n/pps/pps.html){:target="_blank"}
+  * [ Ultraviolet Spectrometer (UVS) team report]({{ site.assets_url }}voyager/reference/science_v2n/uvs/uvs.html){:target="_blank"}
+  * [ Magnetic Fields (MAG) team report]({{ site.assets_url }}voyager/reference/science_v2n/mag/mag.html){:target="_blank"}
+  * [ Cosmic Ray (CRS) team report]({{ site.assets_url }}voyager/reference/science_v2n/crs/crs.html){:target="_blank"}
+  * [ Plasma Wave (PWS) team report]({{ site.assets_url }}voyager/reference/science_v2n/pws/pws.html){:target="_blank"}
 
 For further reading, consult the following:
 
-  * Hubbard, W. B., A. Brahic, B. Sicardy, L. R. Elicer, F. Roques, and F. Vilas 1986\. [Occultation detection of a Neptunian ring-like arc.](//ui.adsabs.harvard.edu/abs/1986Natur.319..636H){:target="_blank"} _Nature_ **319**, 636-640. 
-  * Porco, C. C. 1991. [ An explanation for Neptune's ring arcs.](//ui.adsabs.harvard.edu/abs/1991Sci...253..995P){:target="_blank"} _Science_ **253**, 995-1001. 
-  * Porco, C. C., P. D. Nicholson, J. N. Cuzzi, J. J. Lissauer, and L. W. Esposito 1995\. [Neptune's ring system.](//ui.adsabs.harvard.edu/abs/1995netr.conf..703P){:target="_blank"} In _Neptune and Triton_, (D. P. Cruikshank, Ed.), University of Arizona Press, Tucson, in press. 
-
+  * Hubbard, W. B., A. Brahic, B. Sicardy, L. R. Elicer, F. Roques, and F. Vilas 1986\. [Occultation detection of a Neptunian ring-like arc.](//ui.adsabs.harvard.edu/abs/1986Natur.319..636H){:target="_blank"} _Nature_ **319**, 636-640.
+  * Porco, C. C. 1991. [ An explanation for Neptune's ring arcs.](//ui.adsabs.harvard.edu/abs/1991Sci...253..995P){:target="_blank"} _Science_ **253**, 995-1001.
+  * Porco, C. C., P. D. Nicholson, J. N. Cuzzi, J. J. Lissauer, and L. W. Esposito 1995\. [Neptune's ring system.](//ui.adsabs.harvard.edu/abs/1995netr.conf..703P){:target="_blank"} In _Neptune and Triton_, (D. P. Cruikshank, Ed.), University of Arizona Press, Tucson, in press.

--- a/website/voyager/pps/data.html
+++ b/website/voyager/pps/data.html
@@ -9,7 +9,7 @@ tabs: voyager_pps
 
 The PPS instrument acquired stellar occultation profiles of the ring systems
 of Saturn, Uranus, and Neptune. In general, these were obtained simultaneously
-with the [UVS](/voyager/uvs/index.html) instrument.
+with the [UVS]({{ site.baseurl }}/voyager/uvs/index.html) instrument.
 
 Volume **VG_2801** contains the complete Voyager PPS occultation data set.
 Included are raw data, calibrated profiles, ancillary data, documentation, and
@@ -17,7 +17,7 @@ support software.
 
   * Browse the [on-line volume]({{ site.viewmaster_url }}volumes/VG_28xx/VG_2801/){:target="_blank"}
 
-  * Download the entire volume as a [bundled volume ]({{ site.holdings_url }}archives-volumes/VG_28xx/VG_2801.tar.gz) in [tar.gz](/help/targz.html) format.
+  * Download the entire volume as a [bundled volume ]({{ site.holdings_url }}archives-volumes/VG_28xx/VG_2801.tar.gz) in [tar.gz]({{ site.baseurl }}/help/targz.html) format.
 
 For an overview of the data set, see
 
@@ -28,9 +28,8 @@ For an overview of the data set, see
 
 For more information, consult the CATALOG files:
 
-  * [DATASET.CAT]({{ site.holdings_url }}volumes/VG_28xx/VG_2801/CATALOG/DATASET.CAT){:target="_blank"}: PPS data set information. 
-  * [DSCOLL.CAT]({{ site.holdings_url }}volumes/VG_28xx/VG_2801/CATALOG/DSCOLL.CAT){:target="_blank"}: Information about the data set collection, comprising the PPS [UVS](/voyager/uvs/), and [RSS](/voyager/rss/) ring occultation experiments. 
-  * [PERSON.CAT]({{ site.holdings_url }}volumes/VG_28xx/VG_2801/CATALOG/PERSON.CAT){:target="_blank"}: Contact information for the PPS team members and the individuals involved in the production of this data set. 
-  * [REF.CAT]({{ site.holdings_url }}volumes/VG_28xx/VG_2801/CATALOG/REF.CAT){:target="_blank"}: Bibliographic references. 
-  * [VOLDESC.CAT]({{ site.holdings_url }}volumes/VG_28xx/VG_2801/VOLDESC.CAT){:target="_blank"}: Brief description of the archive volume. 
-
+  * [DATASET.CAT]({{ site.holdings_url }}volumes/VG_28xx/VG_2801/CATALOG/DATASET.CAT){:target="_blank"}: PPS data set information.
+  * [DSCOLL.CAT]({{ site.holdings_url }}volumes/VG_28xx/VG_2801/CATALOG/DSCOLL.CAT){:target="_blank"}: Information about the data set collection, comprising the PPS [UVS]({{ site.baseurl }}/voyager/uvs/), and [RSS]({{ site.baseurl }}/voyager/rss/) ring occultation experiments.
+  * [PERSON.CAT]({{ site.holdings_url }}volumes/VG_28xx/VG_2801/CATALOG/PERSON.CAT){:target="_blank"}: Contact information for the PPS team members and the individuals involved in the production of this data set.
+  * [REF.CAT]({{ site.holdings_url }}volumes/VG_28xx/VG_2801/CATALOG/REF.CAT){:target="_blank"}: Bibliographic references.
+  * [VOLDESC.CAT]({{ site.holdings_url }}volumes/VG_28xx/VG_2801/VOLDESC.CAT){:target="_blank"}: Brief description of the archive volume.

--- a/website/voyager/pps/instrument.html
+++ b/website/voyager/pps/instrument.html
@@ -5,7 +5,7 @@ title: PPS Instrument Description
 tabs: voyager_pps
 ---
 
-![]({{ site.assets_url }}/voyager/pps/pps_face.gif) ![]({{ site.assets_url }}/voyager/pps/pps_side.gif)
+![]({{ site.assets_url }}voyager/pps/pps_face.gif) ![]({{ site.assets_url }}voyager/pps/pps_side.gif)
 
 ## [{{ page.title }}](inst_cat.html)
 

--- a/website/voyager/rss/index.html
+++ b/website/voyager/rss/index.html
@@ -22,21 +22,20 @@ Ring-Moon Systems Node.
   * Download the entire volume as a [bundled volume ]({{ site.viewmaster_url }}archives-volumes/VG_28xx/VG_2803.tar.gz)
 
 The bundled volume is in .tar.gz format. For information on opening files of
-this type, click [here](/help/targz.html).
+this type, click [here]({{ site.baseurl }}/help/targz.html).
 
 For an overview of the data set, see [AAREADME.TXT]({{ url }}AAREADME.TXT){:target="_blank"} and
 [TUTORIAL.TXT]({{ url }}DOCUMENT/TUTORIAL.TXT){:target="_blank"}.
 
 For more information, consult the CATALOG files:
 
-  * [DATASET.CAT]({{ url }}CATALOG/DATASET.CAT){:target="_blank"}: RSS data set information. 
-  * [DSCOLL.CAT]({{ url }}CATALOG/DSCOLL.CAT){:target="_blank"}: Information about the data set collection, comprising the PPS, UVS and RSS ring occultation experiments. 
-  * [VG1SINST.CAT]({{ url }}CATALOG/VG1SINST.CAT){:target="_blank"}: RSS instrument description for Voyager 1 at Saturn. 
-  * [VG2UINST.CAT]({{ url }}CATALOG/VG2UINST.CAT){:target="_blank"}: RSS instrument description for Voyager 2 at Uranus. 
-  * [VG1HOST.CAT]({{ url }}CATALOG/VG1HOST.CAT){:target="_blank"}: Voyager 1 spacecraft description. 
-  * [VG2HOST.CAT]({{ url }}CATALOG/VG2HOST.CAT){:target="_blank"}: Voyager 2 spacecraft description. 
-  * [MISSION.CAT]({{ url }}CATALOG/MISSION.CAT){:target="_blank"}: Description of the Voyager mission overall. 
-  * [PERSON.CAT]({{ url }}CATALOG/PERSON.CAT){:target="_blank"}: Contact information for the RSS team members and the individuals involved in the production of this data set. 
-  * [REF.CAT]({{ url }}CATALOG/REF.CAT){:target="_blank"}: Bibliographic references. 
-  * [VOLDESC.CAT]({{ url }}VOLDESC.CAT){:target="_blank"}: Brief description of the archive volume. 
-
+  * [DATASET.CAT]({{ url }}CATALOG/DATASET.CAT){:target="_blank"}: RSS data set information.
+  * [DSCOLL.CAT]({{ url }}CATALOG/DSCOLL.CAT){:target="_blank"}: Information about the data set collection, comprising the PPS, UVS and RSS ring occultation experiments.
+  * [VG1SINST.CAT]({{ url }}CATALOG/VG1SINST.CAT){:target="_blank"}: RSS instrument description for Voyager 1 at Saturn.
+  * [VG2UINST.CAT]({{ url }}CATALOG/VG2UINST.CAT){:target="_blank"}: RSS instrument description for Voyager 2 at Uranus.
+  * [VG1HOST.CAT]({{ url }}CATALOG/VG1HOST.CAT){:target="_blank"}: Voyager 1 spacecraft description.
+  * [VG2HOST.CAT]({{ url }}CATALOG/VG2HOST.CAT){:target="_blank"}: Voyager 2 spacecraft description.
+  * [MISSION.CAT]({{ url }}CATALOG/MISSION.CAT){:target="_blank"}: Description of the Voyager mission overall.
+  * [PERSON.CAT]({{ url }}CATALOG/PERSON.CAT){:target="_blank"}: Contact information for the RSS team members and the individuals involved in the production of this data set.
+  * [REF.CAT]({{ url }}CATALOG/REF.CAT){:target="_blank"}: Bibliographic references.
+  * [VOLDESC.CAT]({{ url }}VOLDESC.CAT){:target="_blank"}: Brief description of the archive volume.

--- a/website/voyager/uvs/data.html
+++ b/website/voyager/uvs/data.html
@@ -11,7 +11,7 @@ holdings_folder: volumes/VG_28xx/VG_2802/
 
 The UVS instrument acquired stellar occultation profiles of the ring systems
 of Saturn, Uranus, and Neptune. In general, these were obtained simultaneously
-with the [PPS](/voyager/pps/index.html) instrument.
+with the [PPS]({{ site.baseurl }}/voyager/pps/index.html) instrument.
 
 Volume **VG_2802** contains the complete Voyager UVS occultation data set.
 Included are raw data, calibrated profiles, ancillary data, documentation, and
@@ -22,7 +22,7 @@ support software.
   * Download the entire volume as a [bundled volume ]({{ site.viewmaster_url }}archives-volumes/VG_28xx/VG_2802.tar.gz)
 
 The bundled volume is in .tar.gz format. For information on opening files of
-this type, click [here](/help/targz.html).
+this type, click [here]({{ site.baseurl }}/help/targz.html).
 
 For an overview of the data set, see
 
@@ -33,8 +33,8 @@ For an overview of the data set, see
 
 For more information, consult the CATALOG files:
 
-  * [DATASET.CAT]({{ holdings }}CATALOG/DATASET.CAT){:target="_blank"}: UVS data set information. 
-  * [DSCOLL.CAT]({{ holdings }}CATALOG/DSCOLL.CAT){:target="_blank"}: Information about the data set collection, comprising the [PPS](/voyager/pps/), UVS, and [RSS](/voyager/rss/) ring occultation experiments. 
-  * [PERSON.CAT]({{ holdings }}CATALOG/PERSON.CAT){:target="_blank"}: Contact information for the UVS team members and the individuals involved in the production of this data set. 
-  * [REF.CAT]({{ holdings }}CATALOG/REF.CAT){:target="_blank"}: Bibliographic references. 
-  * [VOLDESC.CAT]({{ holdings }}VOLDESC.CAT){:target="_blank"}: Brief description of the archive volume. 
+  * [DATASET.CAT]({{ holdings }}CATALOG/DATASET.CAT){:target="_blank"}: UVS data set information.
+  * [DSCOLL.CAT]({{ holdings }}CATALOG/DSCOLL.CAT){:target="_blank"}: Information about the data set collection, comprising the [PPS]({{ site.baseurl }}/voyager/pps/), UVS, and [RSS]({{ site.baseurl }}/voyager/rss/) ring occultation experiments.
+  * [PERSON.CAT]({{ holdings }}CATALOG/PERSON.CAT){:target="_blank"}: Contact information for the UVS team members and the individuals involved in the production of this data set.
+  * [REF.CAT]({{ holdings }}CATALOG/REF.CAT){:target="_blank"}: Bibliographic references.
+  * [VOLDESC.CAT]({{ holdings }}VOLDESC.CAT){:target="_blank"}: Brief description of the archive volume.


### PR DESCRIPTION
- Added `{{ site.baseurl }}` in front of all internal links. In some cases I used `| relative_path` instead, which does the same thing. For consistency with jekyll documentation, I did not put a `/` at the end of `baseurl`, thus leaving the existing URLs as `/a/b/c` if `baseurl` is empty. This is different from `assets_url` and `holdings_url`, which must be defined and must end with `/`.
- Fixed a couple of places where `{{ site.assets_url }}` was followed by `/`, resulting in `//` in the generated webpage.
- Fixed a missing `/` in the external link in `voyager/crs/index.html` which caused a broken external link.
- Cleaned up a little bit of tab confusion.
- Some other cosmetic changes like trailing spaces being deleted were just done automatically by my editor on save. I would recommend you set up VS Code to do the same thing. If you want to ignore the whitespace changes you can use the gear tool at the top of the Files page and select "Hide whitespace".

I verified that I did not mess up the webpage by generating it with `baseurl` set to `""` and comparing the generated files with those from the current `main` branch. There were no changes other than the few bugs mentioned above.

See the comment below with the link to the branch deployment. You can click on that URL to see this particular branch deployed on `staging`. No need to login to staging to deploy it yourself!