### PR TITLE
Update asset links to holdings in New Horizons

### DIFF
--- a/website/_data/tables/newhorizons_access.yaml
+++ b/website/_data/tables/newhorizons_access.yaml
@@ -13,7 +13,7 @@
 
 # Edit Below:
 - section:
-    heading1: Post Launch Cruise
+    heading1: Cruise to Jupiter
 
     section_rows:
 
@@ -42,7 +42,7 @@
             description: Calib MVIC
 
 - section:
-    heading1: Jupiter Encounter
+    heading1: Jupiter Flyby
 
     section_rows:
 
@@ -71,7 +71,7 @@
             description: Calib MVIC
 
 - section:
-    heading1: Pluto Cruise
+    heading1: Cruise to Pluto
 
     section_rows:
 
@@ -100,7 +100,7 @@
             description: Calib MVIC
 
 - section:
-    heading1: Pluto Encounter
+    heading1: Pluto Flyby & Cruise
 
     section_rows:
 
@@ -129,7 +129,7 @@
             description: Calib MVIC
 
 - section:
-    heading1: Arrokoth Cruise
+    heading1: Cruise to Arrokoth
 
     section_rows:
 
@@ -187,7 +187,7 @@
             description: Calib MVIC
 
 - section:
-    heading1: KEM2 extended Kuiper Belt mission
+    heading1: “KEM2” Extended Kuiper Belt Mission
 
     section_rows:
 

--- a/website/_data/tables/newhorizons_access.yaml
+++ b/website/_data/tables/newhorizons_access.yaml
@@ -174,11 +174,6 @@
             liens: None
             description: Calib LORRI
 
-- section:
-    heading1: Arrokoth Flyby
-
-    section_rows:
-
         - table_row:
             id: NHKEMV_1001
             base_dir:  NHxxMV_xxxx

--- a/website/_data/tables/newhorizons_access.yaml
+++ b/website/_data/tables/newhorizons_access.yaml
@@ -127,3 +127,83 @@
             base_dir:  NHxxMV_xxxx
             liens: None
             description: Calib MVIC
+
+- section:
+    heading1: Arrokoth Cruise
+
+    section_rows:
+
+        - table_row:
+            id: NHKCLO_1001
+            base_dir:  NHxxLO_xxxx
+            liens: None
+            description: Raw LORRI
+
+        - table_row:
+            id: NHKCLO_2001
+            base_dir:  NHxxLO_xxxx
+            liens: None
+            description: Calib LORRI
+
+        - table_row:
+            id: NHKCMV_1001
+            base_dir:  NHxxMV_xxxx
+            liens: None
+            description: Raw MVIC
+
+        - table_row:
+            id: NHKCMV_2001
+            base_dir:  NHxxMV_xxxx
+            liens: None
+            description: Calib MVIC
+
+- section:
+    heading1: Arrokoth Flyby & Cruise
+
+    section_rows:
+
+        - table_row:
+            id: NHKELO_1001
+            base_dir:  NHxxLO_xxxx
+            liens: None
+            description: Raw LORRI
+
+        - table_row:
+            id: NHKELO_2001
+            base_dir:  NHxxLO_xxxx
+            liens: None
+            description: Calib LORRI
+
+- section:
+    heading1: Arrokoth Flyby
+
+    section_rows:
+
+        - table_row:
+            id: NHKEMV_1001
+            base_dir:  NHxxMV_xxxx
+            liens: None
+            description: Raw MVIC
+
+        - table_row:
+            id: NHKEMV_2001
+            base_dir:  NHxxMV_xxxx
+            liens: None
+            description: Calib MVIC
+
+- section:
+    heading1: KEM2 extended Kuiper Belt mission
+
+    section_rows:
+
+        - table_row:
+            id: NHK2LO_1001
+            base_dir:  NHxxLO_xxxx
+            liens: None
+            description: Raw LORRI
+
+        - table_row:
+            id: NHK2LO_2001
+            base_dir:  NHxxLO_xxxx
+            liens: None
+            description: Calib LORRI

--- a/website/newhorizons/access.html
+++ b/website/newhorizons/access.html
@@ -32,20 +32,8 @@ The bundled volumes are provided in [tar.gz]({{ site.baseurl }}/help/targz.html)
 
   * **Geometry Index** will take you to the index of enhanced geometric metadata for the volume.
 
-  * All of the New Horizons volumes available through the RMS node have completed peer review liens resolution.
-
-  * There are a total of three files which between them cover all of the most recent set of now resolved liens for the data associated with this page:
-
-    * Liens for [LORRI, raw and calibrated for the Post Launch, Jupiter, and Pluto Cruise phases](nhlo_la-ju-pc_liens.txt){:target="_blank"}
-
-    * Liens for [LORRI, raw and calibrated Pluto Encounter](nhpelo_liens.txt){:target="_blank"}
-
-    * Liens for [MVIC, raw and calibrated Pluto Encounter](nhpemv_liens.txt){:target="_blank"}
-
 
 ## Available Volumes
-
-  * To determine which volumes meet the publicly available criteria for a specific ROSES Announcement please see the appropriate DAP page under our [Proposal Support]({{ site.baseurl }}/roses) pages.
 
 {% assign table_name = "New Horizons LORRI and MVIC Releases" %}
 {% assign table_desc = "A listing of New Horizons LORRI and MVIC Releases" %}

--- a/website/newhorizons/index.html
+++ b/website/newhorizons/index.html
@@ -8,7 +8,7 @@ tabs: newhorizons
 
 ##  Introduction
 
-**Last updated: 12/24/2018**
+**Last updated: 08/24/2024**
 
 While all of the New Horizons data are available from the [PDS Small Bodies Node (SBN)](//pds-smallbodies.astro.umd.edu/data_sb/missions/newhorizons/index.shtml){:target="_blank"},
 the Ring-Moon Systems
@@ -28,6 +28,8 @@ Mission phases are:
   * JU - Jupiter Encounter
   * PC - Pluto Cruise
   * PE - Pluto Encounter
+  * KC - Arrokoth Cruise
+  * K2 - KEM2 Extended Kuiper Belt Mission
 
 For the Pluto Encounter, because of the long transfer time from the spacecraft, data are
 being released incrementally. The spacecraft downloads are prioritized by content, not chronology.
@@ -60,15 +62,15 @@ these documents in the DOCUMENT sub-directory of each volume.
 
 As a minimum, users of the LORRI data should review the following documents:
 
-  * [AAREADME](nh_AAREADME.TXT){:target="_blank"}. Provides an overview of the data set.
-  * [ICD](SOC_INST_ICD.PDF){:target="_blank"}. Contains general information and details of the LORRI instrument and data.
-  * [LORRI SR](LORRI_SSR.PDF){:target="_blank"}. The LORRI article submitted to <i>Space Science Reviews</i>.
-  * [LORRI Distortion](owen_lorri_distortion_nhcal06-1.pdf){:target="_blank"}. Provides additional information regarding the Distortion Model for LORRI (not included in the volumes).
+  * aareadme.txt - Provides an overview of the data set.
+  * soc_inst_icd/soc_inst_icd.pdf - Contains general information and details of the LORRI instrument and data.
+  * lorri_ssr/lorri_ssr.pdf - The LORRI article submitted to <i>Space Science Reviews</i>.
+  * [LORRI Distortion]({{ site.assets_url }}owen_lorri_distortion_nhcal06-1.pdf){:target="_blank"} - Provides additional information regarding the Distortion Model for LORRI (not included in the volumes).
 
 For information on the geometry data included in the labels and metadata, see
 the
 
-  * [Quaternion description](QUAT_AXYZ_J2K_TO_INSTR.ASC){:target="_blank"} file and its associated [label file.](QUAT_AXYZ_J2K_TO_INSTR.LBL){:target="_blank"}
+  * quat_axyz_instr_to_j2k.asc - Quaternion description file and its associated label file quat_axyz_instr_to_j2k.lbl.
 
 
 ## Ring Observation "Tour Guide"
@@ -76,9 +78,9 @@ the
 Mark Showalter has assembled a table of all the LORRI Jupiter ring observations, including a
 brief description of the targeting and the science goals.
 
-  * PDS-formatted table: [lorri_jring_images.tab](lorri_jring_images.tab){:target="_blank"}
-  * PDS3 label: [lorri_jring_images.lbl](lorri_jring_images.lbl){:target="_blank"}
-  * Zip file of all the diagrams: [lorri_jring_image_diagrams.zip](lorri_jring_image_diagrams.zip)
+  * PDS-formatted table: [lorri_jring_images.tab]({{ site.assets_url }}newhorizons/lorri_jring_images.tab){:target="_blank"}
+  * PDS3 label: [lorri_jring_images.lbl]({{ site.assets_url }}newhorizons/lorri_jring_images.lbl){:target="_blank"}
+  * Zip file of all the diagrams: [lorri_jring_image_diagrams.zip]({{ site.assets_url }}newhorizons/lorri_jring_image_diagrams.zip)
 
 
 ## Other Links
@@ -94,5 +96,3 @@ Observational geometry is available from the PDS NAIF Node:
 
 Information on the spacecraft and its instruments is available from the New
 Horizons Mission [Home page](//www.nasa.gov/mission_pages/newhorizons/main/index.html){:target="_blank"}.
-
-If you are unfamiliar with scientific image formats, consider taking Emily Lakdawalla's free on-line course, [Basics of Digital Imaging](//courses.planetary.org/p/imageclass){:target="_blank"}.

--- a/website/newhorizons/index.html
+++ b/website/newhorizons/index.html
@@ -24,13 +24,13 @@ instrument abbreviation, and xxx is the remainder of the volume number.
 
 Mission phases are:
 
-  * LA - Post Launch Cruise
-  * JU - Jupiter Encounter
-  * PC - Pluto Cruise
-  * PE - Pluto Encounter
-  * KC - Arrokoth Cruise
-  * KE - Arrokoth Cruise & Flyby
-  * K2 - KEM2 Extended Kuiper Belt Mission
+  * LA - Cruise to Jupiter
+  * JU - Jupiter Flyby
+  * PC - Cruise to Pluto
+  * PE - Pluto Flyby & Cruise
+  * KC - Cruise to Arrokoth
+  * KE - Arrokoth Flyby & Cruise
+  * K2 - “KEM2” Extended Kuiper Belt Mission
 
 For the Pluto Encounter, because of the long transfer time from the spacecraft, data are
 being released incrementally. The spacecraft downloads are prioritized by content, not chronology.

--- a/website/newhorizons/index.html
+++ b/website/newhorizons/index.html
@@ -29,6 +29,7 @@ Mission phases are:
   * PC - Pluto Cruise
   * PE - Pluto Encounter
   * KC - Arrokoth Cruise
+  * KE - Arrokoth Cruise & Flyby
   * K2 - KEM2 Extended Kuiper Belt Mission
 
 For the Pluto Encounter, because of the long transfer time from the spacecraft, data are


### PR DESCRIPTION
Fixes #132
 - updated links for assets; removed generic holdings file links
- Removed outdated code for Liens and Roses; updated table to include latest files in holdings
- Removed broken link to online course