### PR TITLE
Updated all occurrences/links to staff to new URL

### DIFF
--- a/website/_data/nav.yaml
+++ b/website/_data/nav.yaml
@@ -96,17 +96,17 @@
   submenu:
 
     - title: Matt Tiscareno
-      href: //www.seti.org/our-scientists/matthew-tiscareno
+      href: //www.seti.org/people/matthew-tiscareno
       open: new_tab
 
     - title: Mitch Gordon
-      href: //www.seti.org/our-scientists/mitchell-gordon
+      href: //www.seti.org/people/mitchell-gordon
       open: new_tab
 
     - title: Mark Showalter
-      href: //www.seti.org/our-scientists/mark-showalter
+      href: //www.seti.org/people/mark-showalter
       open: new_tab
 
     - title: Rob French
-      href: //www.seti.org/our-scientists/robert-french
+      href: //www.seti.org/people/robert-french
       open: new_tab

--- a/website/_includes/footer.html
+++ b/website/_includes/footer.html
@@ -12,7 +12,7 @@
         </span>
     </div>
     <div class = "col-lg-4">
-      Node Manager: <span class = "footer-blue"><a href="https://www.seti.org/our-scientists/matthew-tiscareno" class="footer-blue" target="_blank">Matt Tiscareno</a></span><br>
+      Node Manager: <span class = "footer-blue"><a href="https://www.seti.org/people/matthew-tiscareno" class="footer-blue" target="_blank">Matt Tiscareno</a></span><br>
     </div>
   </div>
 </div>

--- a/website/rpx/rpxlogo.html
+++ b/website/rpx/rpxlogo.html
@@ -7,5 +7,5 @@ layout_style: default
  ![\[RPX LOGO\]]({{ site.assets_url }}rpx/rpxlogo.gif)
 
 This logo was designed by Maren Cooke of MIT and
-[Mark Showalter](//www.seti.org/our-scientists/mark-showalter){:target="_blank"}. Please acknowledge the creators and the PDS Rings
+[Mark Showalter](//www.seti.org/people/mark-showalter){:target="_blank"}. Please acknowledge the creators and the PDS Rings
 Node if it is reproduced.

--- a/website/rpx/tucson_1994/index.html
+++ b/website/rpx/tucson_1994/index.html
@@ -76,4 +76,4 @@ agenda is listed below
   * [ Observing Campaign](proceedings/showalter_2/){:target="_blank"}, by M. R. Showalter
 
 **Note:** A hardcopy version of the proceedings may be obtained by sending a request to
-[Dr. Mark Showalter](//www.seti.org/our-scientists/mark-showalter){:target="_blank"}. 
+[Dr. Mark Showalter](//www.seti.org/people/mark-showalter){:target="_blank"}. 

--- a/website/rpx/viewer/examples/index.html
+++ b/website/rpx/viewer/examples/index.html
@@ -19,4 +19,4 @@ You may click on any of these examples for more information:
   [ ![- ]({{ site.assets_url }}rpx/viewer/examples/saturn2_thumb.gif)](saturn2.html)
 
 **Note:** If you publish a figure generated using this utility, please acknowledge
-[Mark Showalter](//www.seti.org/our-scientists/mark-showalter){:target="_blank"} and the PDS Rings Node. 
+[Mark Showalter](//www.seti.org/people/mark-showalter){:target="_blank"} and the PDS Rings Node. 

--- a/website/rpx/wellesley_1997/index.html
+++ b/website/rpx/wellesley_1997/index.html
@@ -65,7 +65,7 @@ This page will be updated regularly as new information becomes available.
 
 ## Organizers
 
-  * [Mark Showalter](www.seti.org/our-scientists/mark-showalter){:target="_blank"} (showalter@—)
+  * [Mark Showalter](//www.seti.org/people/mark-showalter){:target="_blank"} (showalter@—)
   * Phil Nicholson (nicholson@—)
   * Dick French (local organizer, rfrench@—)
 

--- a/website/urpx/urpxlogo.html
+++ b/website/urpx/urpxlogo.html
@@ -4,7 +4,7 @@ layout_style: default
 ---
 
 ![\[URPX LOGO\]]({{ site.assets_url }}urpx/urpx_logo.gif)
-This logo was designed by [Mark Showalter](//www.seti.org/our-scientists/mark-showalter){:target="_blank"}
-and [Mitch Gordon](//www.seti.org/our-scientists/mitchell-gordon){:target="_blank"}.
+This logo was designed by [Mark Showalter](//www.seti.org/people/mark-showalter){:target="_blank"}
+and [Mitch Gordon](//www.seti.org/people/mitchell-gordon){:target="_blank"}.
 
 Please acknowledge the creators and the PDS Ring-Moon Systems Node if it is reproduced.

--- a/website/voyager/ck/index.html
+++ b/website/voyager/ck/index.html
@@ -37,7 +37,7 @@ provide nearly complete temporal coverage of each encounter. However, the
 accuracy is not as good as that of the ISS SEDR files.
 
 These files will be posted on line shortly, along with complete descriptive
-information. Meanwhile, contact [Mark Showalter](//www.seti.org/our-scientists/mark-showalter){:target="_blank"} if you
+information. Meanwhile, contact [Mark Showalter](//www.seti.org/people/mark-showalter){:target="_blank"} if you
 would like any of these files.
 
 ## C Kernels
@@ -79,7 +79,7 @@ nearly-complete temporal coverage.
 
 **NOTE**: These files have not yet been through peer review. We believe them to
 be accurate but further testing is probably appropriate. Please send any questions
-or problems to [Matt Tiscareno](//www.seti.org/our-scientists/matthew-tiscareno){:target="_blank"}.
+or problems to [Matt Tiscareno](//www.seti.org/people/matthew-tiscareno){:target="_blank"}.
 
 ## Downloads
 


### PR DESCRIPTION
There were actually 8 files that had links to the older version of staff links, so all of those links were updated to the new format.

www.seti.org/our-scientists/   to  www.seti.org/people/