### PR TITLE
Add Cassini ISS Calibrated info to RMS Annex index page

### DIFF
--- a/website/ringocc/index.html
+++ b/website/ringocc/index.html
@@ -118,7 +118,7 @@ Neptune, Titan, and Triton, covering the years 2023-2050.
 
 
 These directories are [Supplemental Online Material]({{ site.rms-annex_url }}french23_occult_pred/SOM/){:target="_blank"} 
-supporting the article, [Richard G. French and Damya Souami 2023, Planet. Sci. J. 4 202, 10.3847/PSJ/aced50](////ui.adsabs.harvard.edu/abs/2023PSJ.....4..202F/abstract){:target="_blank"}. 
+supporting the article, [Richard G. French and Damya Souami 2023, Planet. Sci. J. 4 202, 10.3847/PSJ/aced50](//ui.adsabs.harvard.edu/abs/2023PSJ.....4..202F/abstract){:target="_blank"}. 
 The directory organization and contents are fully described in the journal article.
 
 &nbsp;

--- a/website/rms-annex/index.html
+++ b/website/rms-annex/index.html
@@ -23,3 +23,13 @@ covering the years 2023-2050
   * References:
     * Earth-based Stellar Occultation Predictions for Jupiter, Saturn, Uranus, Neptune, Titan, and Triton: 2023, 
       [Richard G. French and Damya Souami 2023, Planet. Sci. J. 4 202, 10.3847/PSJ/aced50](////ui.adsabs.harvard.edu/abs/2023PSJ.....4..202F/abstract){:target="_blank"}
+
+### **Cassini ISS Calibrated**
+
+Calibrated data from the Cassini Imaging Science Subsystem (ISS), covering the years 1999-2017
+  * [Directory listing](https://pds-rings.seti.org/holdings/calibrated/)
+  * Comments:
+    * Derived from the Cassini ISS raw images, archived [here](https://pds-rings.seti.org/holdings/volumes/COISS_1xxx/) and [here](https://pds-rings.seti.org/holdings/volumes/COISS_2xxx/)
+    * Created using the Cassini ISS Calibration (CISSCAL) software, archived [here](https://pds-rings.seti.org/holdings/volumes/COISS_0xxx/)
+    * These data files are not part of the PDS3 archive, because they were never peer reviewed
+    * These data files will soon be archived in the PDS4 format

--- a/website/rms-annex/index.html
+++ b/website/rms-annex/index.html
@@ -22,7 +22,7 @@ covering the years 2023-2050
   * [Documents directory]({{ site.rms-annex_url }}french23_occult_pred/SOM/doc){:target="_blank"}
   * References:
     * Earth-based Stellar Occultation Predictions for Jupiter, Saturn, Uranus, Neptune, Titan, and Triton: 2023, 
-      [Richard G. French and Damya Souami 2023, Planet. Sci. J. 4 202, 10.3847/PSJ/aced50](////ui.adsabs.harvard.edu/abs/2023PSJ.....4..202F/abstract){:target="_blank"}
+      [Richard G. French and Damya Souami 2023, Planet. Sci. J. 4 202, 10.3847/PSJ/aced50](//ui.adsabs.harvard.edu/abs/2023PSJ.....4..202F/abstract){:target="_blank"}
 
 ### **Cassini ISS Calibrated**
 

--- a/website/rms-annex/index.html
+++ b/website/rms-annex/index.html
@@ -27,9 +27,9 @@ covering the years 2023-2050
 ### **Cassini ISS Calibrated**
 
 Calibrated data from the Cassini Imaging Science Subsystem (ISS), covering the years 1999-2017
-  * [Directory listing](https://pds-rings.seti.org/holdings/calibrated/)
+  * [Directory listing]({{ site.viewmaster_url }}calibrated)
   * Comments:
-    * Derived from the Cassini ISS raw images, archived [here](https://pds-rings.seti.org/holdings/volumes/COISS_1xxx/) and [here](https://pds-rings.seti.org/holdings/volumes/COISS_2xxx/)
-    * Created using the Cassini ISS Calibration (CISSCAL) software, archived [here](https://pds-rings.seti.org/holdings/volumes/COISS_0xxx/)
+    * Derived from the Cassini ISS raw images, archived [here]({{ site.viewmaster_url }}volumes/COISS_1xxx) and [here]({{ site.viewmaster_url }}volumes/COISS_2xxx)
+    * Created using the Cassini ISS Calibration (CISSCAL) software, archived [here]({{ site.viewmaster_url }}volumes/COISS_0xxx)
     * These data files are not part of the PDS3 archive, because they were never peer reviewed
     * These data files will soon be archived in the PDS4 format

--- a/website/rms-annex/index.html
+++ b/website/rms-annex/index.html
@@ -27,9 +27,9 @@ covering the years 2023-2050
 ### **Cassini ISS Calibrated**
 
 Calibrated data from the Cassini Imaging Science Subsystem (ISS), covering the years 1999-2017
-  * [Directory listing]({{ site.viewmaster_url }}calibrated)
+  * [Directory listing]({{ site.viewmaster_url }}calibrated){:target="_blank"}
   * Comments:
-    * Derived from the Cassini ISS raw images, archived [here]({{ site.viewmaster_url }}volumes/COISS_1xxx) and [here]({{ site.viewmaster_url }}volumes/COISS_2xxx)
-    * Created using the Cassini ISS Calibration (CISSCAL) software, archived [here]({{ site.viewmaster_url }}volumes/COISS_0xxx)
+    * Derived from the Cassini ISS raw images, archived [here]({{ site.viewmaster_url }}volumes/COISS_1xxx){:target="_blank"} and [here]({{ site.viewmaster_url }}volumes/COISS_2xxx){:target="_blank"}
+    * Created using the Cassini ISS Calibration (CISSCAL) software, archived [here]({{ site.viewmaster_url }}volumes/COISS_0xxx){:target="_blank"}
     * These data files are not part of the PDS3 archive, because they were never peer reviewed
     * These data files will soon be archived in the PDS4 format


### PR DESCRIPTION
Fixes #254

I've started with a skeleton edit of the Jekyll source code, which should be sufficient to indicate the content I have in mind.  @dstopp, please finish this off with whatever technical additions are needed. 

Others such as @markshowalter and @mace-space might want to review for content.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a "Cassini ISS Calibrated" content block summarizing calibrated data (1999–2017), with a directory access link and a Comments section covering provenance, processing notes, current archival status, and planned PDS4 archiving.
* **Bug Fixes**
  * Fixed two broken/incorrect links in the References and supporting-article links so URLs resolve correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->