### PR TITLE
Added material to enhanced.html (part 2)

### DIFF
--- a/website/cassini/enhanced.html
+++ b/website/cassini/enhanced.html
@@ -24,14 +24,14 @@ established as an overall clearing house for Cassini support.
     For PDS4 data sets curated by RMS, we have solved this problem by defining a list of mission phases that gives a single consistent value for each moment of time during the mission.  The list is as follows:
 
     * First, short encounters that interrupt longer periods:
-      * Venus 1 Encounter: 1998-116 to 1998-116
-      * Venus 2 Encounter: 1999-175 to 1999-175
-      * Earth Encounter: 1999-230 to 1999-230
-      * Jupiter Encounter: 2000-365 to 2000-365
-      * Phoebe Encounter: 2004-163 to 2004-163
-      * Saturn Orbit Insertion: 2004-183 to 2004-183
-      * Titan A Encounter: 2004-300 to 2004-300
-      * Titan B Encounter: 2004-348 to 2004-348
+      * Venus 1 Encounter: 1998-116
+      * Venus 2 Encounter: 1999-175
+      * Earth Encounter: 1999-230
+      * Jupiter Encounter: 2000-365
+      * Phoebe Encounter: 2004-163
+      * Saturn Orbit Insertion: 2004-183
+      * Titan A Encounter: 2004-300
+      * Titan B Encounter: 2004-348
 
     * Then, full-length periods that completely cover the mission timeline:
       * Interplanetary Cruise: 1997-001 to 1999-311
@@ -39,9 +39,9 @@ established as an overall clearing house for Cassini support.
       * Science Cruise: 2002-189 to 2004-011
       * Approach Science: 2004-012 to 2004-162
       * Tour Pre-Huygens: 2004-163 to 2004-358
-      * Huygens Probe Separation: 2004-359 to 2004-359
+      * Huygens Probe Separation: 2004-359
       * Huygens Descent: 2004-360 to 2005-013
-      * Titan C Huygens: 2005-014 to 2005-014
+      * Titan C Huygens: 2005-014
       * Tour: 2005-015 to 2008-182
       * Equinox Mission: 2008-183 to 2010-272
       * Solstice Mission: 2010-273 to end of mission


### PR DESCRIPTION
This is a continuation of #262.  I noticed that some of the phases are only one day long, so I condensed phrases such as "1998-116 to 1998-116" to read simply "1998-116".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated mission phase dates to display as single-date values instead of date ranges for Cassini mission encounters and events, including Venus, Earth, Jupiter, Phoebe, Saturn Orbit Insertion, Titan, and Huygens Probe phases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->